### PR TITLE
Feature/watchlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,22 @@ on:
     branches: [main, master, develop]
 
 jobs:
+  tooling:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Docker compose file
+        run: docker compose config
+
+      - name: Validate Bash dev helper syntax
+        run: bash -n scripts/dev.sh
+
+      - name: Validate PowerShell dev helper
+        shell: pwsh
+        run: ./scripts/dev.ps1 help
+
   frontend:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ node_modules/
 .nuxt/
 .svelte-kit/
 .turbo/
+.wrangler/
 vite.svg
 *.tsbuildinfo
 coverage/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Open the app at:
 
 - `http://127.0.0.1:5173`
 
+Bootstrap notes:
+
+- The bootstrap scripts install backend Python dependencies, root/frontend npm dependencies, and extension npm dependencies.
+- If you only need to refresh backend deps, use `./scripts/bootstrap.ps1 -SkipNpm` or `./scripts/bootstrap.sh --skip-npm`.
+
 ### Option B: Manual Commands
 
 Windows PowerShell:
@@ -50,9 +55,11 @@ Windows PowerShell:
    - `.\.venv\Scripts\python.exe -m pip install -r backend\requirements.txt`
 2. Install frontend deps:
    - `npm install`
-3. Start backend:
+3. Install extension deps:
+   - `npm install --prefix extension --no-audit --no-fund`
+4. Start backend:
    - `.\.venv\Scripts\python.exe -m uvicorn app.main:app --app-dir backend --reload --env-file backend/.env --host 127.0.0.1 --port 8000`
-4. Start frontend in another terminal:
+5. Start frontend in another terminal:
    - `npm exec -w frontend dev -- --host 127.0.0.1 --port 5173`
 
 macOS/Linux:
@@ -63,47 +70,118 @@ macOS/Linux:
    - `./.venv/bin/python -m pip install -r backend/requirements.txt`
 2. Install frontend deps:
    - `npm install`
-3. Start backend:
+3. Install extension deps:
+   - `npm install --prefix extension --no-audit --no-fund`
+4. Start backend:
    - `./.venv/bin/python -m uvicorn app.main:app --app-dir backend --reload --env-file backend/.env --host 127.0.0.1 --port 8000`
-4. Start frontend in another terminal:
+5. Start frontend in another terminal:
    - `npm run -w frontend dev -- --host 127.0.0.1 --port 5173`
 
-## Testing
+## Unified Dev Helpers
 
-Run all commands from repository root:
+Use these wrappers when you want one stable entrypoint instead of remembering individual commands.
 
-- `py -3.10 -m pytest backend/tests -q`
-- `py -3.10 -m black --check backend`
-- `npm run test:frontend`
-- `npm run -w frontend test -- tests/auth.test.tsx` (single frontend test file)
+PowerShell:
 
-## Code Quality Commands
+- `./scripts/dev.ps1 help`
+- `./scripts/dev.ps1 run backend`
+- `./scripts/dev.ps1 run frontend`
+- `./scripts/dev.ps1 run preview`
+- `./scripts/dev.ps1 run docker`
+- `./scripts/dev.ps1 rebuild backend`
+- `./scripts/dev.ps1 rebuild frontend`
+- `./scripts/dev.ps1 rebuild extension`
+- `./scripts/dev.ps1 rebuild all`
+- `./scripts/dev.ps1 rebuild docker`
 
-Use these before opening a PR to match CI behavior.
+Git Bash / macOS / Linux:
 
-Backend (Python):
+- `./scripts/dev.sh help`
+- `./scripts/dev.sh run backend`
+- `./scripts/dev.sh run frontend`
+- `./scripts/dev.sh run preview`
+- `./scripts/dev.sh run docker`
+- `./scripts/dev.sh rebuild backend`
+- `./scripts/dev.sh rebuild frontend`
+- `./scripts/dev.sh rebuild extension`
+- `./scripts/dev.sh rebuild all`
+- `./scripts/dev.sh rebuild docker`
 
-- Auto-format: `py -3.10 -m black backend`
-- Format check only: `py -3.10 -m black --check backend`
-- Run tests: `py -3.10 -m pytest backend/tests -q`
+## Command Reference
 
-Frontend (React/TypeScript):
+Assume Git Bash on Windows unless noted otherwise. Run commands from the repository root.
 
-- Lint check: `npm run lint:frontend`
-- Lint autofix: `npm run -w frontend lint -- --fix`
-- Run tests: `npm run test:frontend`
+### Formatting and Linting
+
+- Backend format:
+  - `./.venv/Scripts/python.exe -m black backend`
+- Backend format check:
+  - `./.venv/Scripts/python.exe -m black --check backend`
+- Frontend lint:
+  - `npm run lint:frontend`
+- Extension typecheck:
+  - `npm run typecheck:extension`
+
+### Tests
+
+- Backend test suite:
+  - `./.venv/Scripts/python.exe -m pytest backend/tests -q`
+- Frontend test suite:
+  - `npm run test:frontend`
+- Extension test suite:
+  - `npm run test:extension`
+- Full repo verification sequence:
+  - `./.venv/Scripts/python.exe -m black --check backend`
+  - `npm run lint:frontend`
+  - `./.venv/Scripts/python.exe -m pytest backend/tests -q`
+  - `npm run test:frontend`
+  - `npm run typecheck:extension`
+  - `npm run test:extension`
+  - `docker compose config`
+
+### Builds
+
+- Frontend build:
+  - `npm run build:frontend`
+- Frontend local production preview:
+  - `npm run preview:frontend`
+- Extension build:
+  - `npm run build:extension`
+- Backend local build-equivalent smoke check:
+  - `./.venv/Scripts/python.exe -m compileall backend/app`
+- Docker builds:
+  - `docker compose build backend`
+  - `docker compose build frontend`
+  - `docker compose build backend frontend`
+
+### Local Deployment
+
+- Backend only:
+  - `./scripts/dev.sh run backend`
+- Frontend only:
+  - `./scripts/dev.sh run frontend`
+- Frontend preview against local assets/worker runtime:
+  - `./scripts/dev.sh run preview`
+- Dockerized local frontend + backend:
+  - `./scripts/dev.sh run docker`
+- Direct Docker commands:
+  - `docker compose up`
+  - `docker compose up --build`
+  - `docker compose down`
 
 CI currently runs:
 
+- Tooling/infrastructure: `docker compose config`, Bash helper syntax check, PowerShell helper smoke run
 - Frontend: lint, build, test
 - Backend: `black --check backend` and `pytest backend/tests`
 - Extension: typecheck, test, build
 
 ## Deployment
 
-Render + Cloudflare Pages deployment is wired around:
+Render + Cloudflare Workers deployment is wired around:
 
 - `render.yaml` for the backend blueprint
+- `frontend/wrangler.jsonc` plus `frontend/worker/index.ts` for the Cloudflare edge proxy/static frontend
 - `backend/.env.production.example` for backend production env reference values
 - `frontend/.env.production.example` for production env reference values
 
@@ -241,7 +319,8 @@ Backend auth/runtime env vars:
 - `SUPABASE_JWT_SECRET` (alternative to JWKS)
 - `ANALYSIS_PROVIDER_MODE` (`deterministic` default, `ai` for AI-backed mode)
 - `ANALYSIS_AI_PROVIDER_KIND` (`gemini` default, or `openai_compatible`)
-- `ANALYSIS_GEMINI_API_KEY` and `ANALYSIS_GEMINI_MODEL` (Gemini mode)
+- `ANALYSIS_GEMINI_API_KEY` and `ANALYSIS_GEMINI_MODEL` (Gemini mode, `gemini-2.5-flash` recommended)
+- `ANALYSIS_GEMINI_MAX_INPUT_TOKENS` and `ANALYSIS_GEMINI_ESTIMATED_CHARS_PER_TOKEN` (Gemini prompt budget guard)
 - `ANALYSIS_OPENAI_COMPATIBLE_API_KEY` and `ANALYSIS_OPENAI_COMPATIBLE_MODEL` (OpenAI-compatible mode)
 - `ANALYSIS_AI_FALLBACK_TO_DETERMINISTIC` (`true` recommended)
 - `ANALYSIS_EXECUTION_MODE` (`sync` active; seam for future queued/worker mode)

--- a/README.md
+++ b/README.md
@@ -228,13 +228,13 @@ PERSISTENCE_BACKEND=memory
 AUTH_REQUIRE_JWT_SIGNATURE_VERIFICATION=true
 SUPABASE_URL=https://<your-project-ref>.supabase.co
 SUPABASE_JWT_AUDIENCE=authenticated
-CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
+CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://localhost:4173,http://127.0.0.1:4173
 ```
 
 If extension analyze calls fail with CORS, append extension origin:
 
 ```env
-CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,chrome-extension://<your-extension-id>
+CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://localhost:4173,http://127.0.0.1:4173,chrome-extension://<your-extension-id>
 ```
 
 Restart backend after editing `backend/.env`.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -52,8 +52,13 @@ ANALYSIS_AI_PROVIDER_KIND=gemini
 
 # Gemini native provider settings.
 ANALYSIS_GEMINI_API_KEY=
-ANALYSIS_GEMINI_MODEL=gemini-2.0-flash
+ANALYSIS_GEMINI_MODEL=gemini-2.5-flash
 ANALYSIS_GEMINI_BASE_URL=https://generativelanguage.googleapis.com/v1beta
+# Gemini 2.5 Flash supports a larger context window, but the free Gemini API
+# tier currently exposes a 250,000 input-token budget. Keep the default limit
+# aligned with that free-tier ceiling unless you intentionally raise it.
+ANALYSIS_GEMINI_MAX_INPUT_TOKENS=250000
+ANALYSIS_GEMINI_ESTIMATED_CHARS_PER_TOKEN=3
 
 # Generic OpenAI-compatible provider settings.
 ANALYSIS_OPENAI_COMPATIBLE_API_KEY=
@@ -74,6 +79,18 @@ ANALYSIS_AI_FALLBACK_TO_DETERMINISTIC=true
 # Internal analysis execution mode seam.
 # Current implementation supports sync only; unknown modes fall back to sync.
 ANALYSIS_EXECUTION_MODE=sync
+
+# Transport-layer abuse protection.
+# These defaults keep general API traffic modest, slow down repeated agreement
+# creation, and add tighter budgets around AI generation endpoints.
+API_RATE_LIMIT_REQUESTS_PER_WINDOW=60
+API_RATE_LIMIT_WINDOW_SECONDS=60
+AGREEMENT_CREATE_RATE_LIMIT_REQUESTS=10
+AGREEMENT_CREATE_RATE_LIMIT_WINDOW_SECONDS=600
+ANALYSIS_RATE_LIMIT_REQUESTS=5
+ANALYSIS_RATE_LIMIT_WINDOW_SECONDS=300
+ANALYSIS_HOURLY_RATE_LIMIT_REQUESTS=20
+ANALYSIS_HOURLY_RATE_LIMIT_WINDOW_SECONDS=3600
 
 # Optional for local extension runtime testing:
 # append your unpacked extension origin after loading it in Chrome if

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -37,8 +37,9 @@ SUPABASE_JWT_LEEWAY_SECONDS=30
 
 # Comma-separated CORS origins for dashboard/extension clients.
 # Add your deployed Cloudflare Pages origin(s) in production, for example:
-# CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,https://your-project.pages.dev,https://app.example.com
-CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
+# Include both Vite dev (`5173`) and local preview (`4173`) origins by default.
+# CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://localhost:4173,http://127.0.0.1:4173,https://your-project.pages.dev,https://app.example.com
+CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://localhost:4173,http://127.0.0.1:4173
 
 # Analysis provider selection.
 # Default keeps deterministic provider active.
@@ -96,5 +97,5 @@ ANALYSIS_HOURLY_RATE_LIMIT_WINDOW_SECONDS=3600
 # append your unpacked extension origin after loading it in Chrome if
 # extension analysis requests are blocked by browser/backend CORS handling.
 # Example:
-# CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,chrome-extension://abcdefghijklmnopabcdefghijklmnop
+# CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://localhost:4173,http://127.0.0.1:4173,chrome-extension://abcdefghijklmnopabcdefghijklmnop
 # Restart backend after changing this value.

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -60,7 +60,9 @@ ANALYSIS_PROVIDER_MODE=deterministic
 
 # Gemini configuration (if using AI mode)
 # ANALYSIS_GEMINI_API_KEY=your-gemini-api-key
-# ANALYSIS_GEMINI_MODEL=gemini-2.0-flash
+# ANALYSIS_GEMINI_MODEL=gemini-2.5-flash
+# ANALYSIS_GEMINI_MAX_INPUT_TOKENS=250000
+# ANALYSIS_GEMINI_ESTIMATED_CHARS_PER_TOKEN=3
 
 # OpenAI-compatible configuration (if using AI mode)
 # ANALYSIS_OPENAI_COMPATIBLE_API_KEY=your-api-key
@@ -76,6 +78,24 @@ ANALYSIS_PROVIDER_MODE=deterministic
 
 # Keep as "sync" for MVP deployment
 ANALYSIS_EXECUTION_MODE=sync
+
+# =============================================================================
+# Abuse Protection
+# =============================================================================
+
+# Coarse API protection against scraping and repeated automated requests
+API_RATE_LIMIT_REQUESTS_PER_WINDOW=60
+API_RATE_LIMIT_WINDOW_SECONDS=60
+
+# Tighter write-side protection for agreement creation
+AGREEMENT_CREATE_RATE_LIMIT_REQUESTS=10
+AGREEMENT_CREATE_RATE_LIMIT_WINDOW_SECONDS=600
+
+# Strict budgets for AI-backed or deterministic analysis generation endpoints
+ANALYSIS_RATE_LIMIT_REQUESTS=5
+ANALYSIS_RATE_LIMIT_WINDOW_SECONDS=300
+ANALYSIS_HOURLY_RATE_LIMIT_REQUESTS=20
+ANALYSIS_HOURLY_RATE_LIMIT_WINDOW_SECONDS=3600
 
 # =============================================================================
 # Application Environment

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,20 @@
+# Development-focused backend image for local docker-compose use.
+# This mirrors the existing scripts/README workflow: install Python deps once,
+# bind-mount the backend source, and run uvicorn with live reload enabled.
+
+FROM python:3.10-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    WATCHFILES_FORCE_POLLING=true
+
+COPY requirements.txt ./requirements.txt
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 8000
+
+CMD ["sh", "-c", "if [ -f /app/.env ]; then uvicorn app.main:app --app-dir /app --reload --env-file /app/.env --host 0.0.0.0 --port 8000; else echo 'Warning: backend/.env not found. Using process environment only.'; uvicorn app.main:app --app-dir /app --reload --host 0.0.0.0 --port 8000; fi"]

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -4,10 +4,11 @@ Repository implementations are selected via config so routes/services remain
 unchanged whether persistence is memory or Postgres/Supabase.
 """
 
-from fastapi import Header, HTTPException
+from fastapi import Header, HTTPException, Request
 
 from ..auth import (
     AuthSubjectResolver,
+    ResolvedSubject,
     SubjectResolutionError,
     build_request_subject_resolver,
 )
@@ -22,6 +23,7 @@ from ..services.ai_provider import AnalysisProviderRuntimeConfig, build_analysis
 from ..services.analysis_service import AnalysisOrchestrationService, RequestSubject
 from ..services.content_ingestion import ContentIngestionService
 from ..services.analysis_execution import build_analysis_execution_strategy
+from ..security import RequestRateLimiter, build_default_rate_limit_policies
 from ..services.submission_preparation import SubmissionPreparationService
 
 
@@ -62,41 +64,6 @@ def _build_persistence_dependencies():
 
 
 _agreement_repository, _report_repository, _persistence_storage = _build_persistence_dependencies()
-# Provider selection is runtime-configured; deterministic remains the safe default
-# when AI mode is disabled or missing required credentials. In AI mode, Gemini
-# is the preferred provider kind unless ANALYSIS_AI_PROVIDER_KIND is overridden.
-_analysis_provider = build_analysis_provider(
-    config=AnalysisProviderRuntimeConfig(
-        mode=settings.analysis_provider_mode,
-        ai_provider_kind=settings.analysis_ai_provider_kind,
-        ai_timeout_seconds=settings.analysis_ai_timeout_seconds,
-        ai_temperature=settings.analysis_ai_temperature,
-        ai_fallback_to_deterministic=settings.analysis_ai_fallback_to_deterministic,
-        openai_compatible_api_key=settings.analysis_openai_compatible_api_key,
-        openai_compatible_model_name=settings.analysis_openai_compatible_model,
-        openai_compatible_base_url=settings.analysis_openai_compatible_base_url,
-        gemini_api_key=settings.analysis_gemini_api_key,
-        gemini_model_name=settings.analysis_gemini_model,
-        gemini_base_url=settings.analysis_gemini_base_url,
-    )
-)
-_analysis_execution_strategy = build_analysis_execution_strategy(
-    # This mode seam keeps request-path sync behavior today while allowing
-    # future queued/worker execution to be introduced behind the same service.
-    mode=settings.analysis_execution_mode,
-    analysis_provider=_analysis_provider,
-    report_repository=_report_repository,
-)
-_content_ingestion_service = ContentIngestionService()
-_submission_preparation_service = SubmissionPreparationService(
-    content_ingestion_service=_content_ingestion_service
-)
-_analysis_service = AnalysisOrchestrationService(
-    agreement_repository=_agreement_repository,
-    report_repository=_report_repository,
-    analysis_execution_strategy=_analysis_execution_strategy,
-    submission_preparation_service=_submission_preparation_service,
-)
 
 
 def _build_subject_resolver() -> AuthSubjectResolver:
@@ -119,6 +86,48 @@ def _build_subject_resolver() -> AuthSubjectResolver:
 
 
 _request_subject_resolver = _build_subject_resolver()
+_request_rate_limiter = RequestRateLimiter(
+    policies=build_default_rate_limit_policies(settings=settings),
+    subject_resolver_provider=lambda: _request_subject_resolver,
+)
+
+# Provider selection is runtime-configured; deterministic remains the safe default
+# when AI mode is disabled or missing required credentials. In AI mode, Gemini
+# is the preferred provider kind unless ANALYSIS_AI_PROVIDER_KIND is overridden.
+_analysis_provider = build_analysis_provider(
+    config=AnalysisProviderRuntimeConfig(
+        mode=settings.analysis_provider_mode,
+        ai_provider_kind=settings.analysis_ai_provider_kind,
+        ai_timeout_seconds=settings.analysis_ai_timeout_seconds,
+        ai_temperature=settings.analysis_ai_temperature,
+        ai_fallback_to_deterministic=settings.analysis_ai_fallback_to_deterministic,
+        openai_compatible_api_key=settings.analysis_openai_compatible_api_key,
+        openai_compatible_model_name=settings.analysis_openai_compatible_model,
+        openai_compatible_base_url=settings.analysis_openai_compatible_base_url,
+        gemini_api_key=settings.analysis_gemini_api_key,
+        gemini_model_name=settings.analysis_gemini_model,
+        gemini_base_url=settings.analysis_gemini_base_url,
+        gemini_max_input_tokens=settings.analysis_gemini_max_input_tokens,
+        gemini_estimated_chars_per_token=settings.analysis_gemini_estimated_chars_per_token,
+    )
+)
+_analysis_execution_strategy = build_analysis_execution_strategy(
+    # This mode seam keeps request-path sync behavior today while allowing
+    # future queued/worker execution to be introduced behind the same service.
+    mode=settings.analysis_execution_mode,
+    analysis_provider=_analysis_provider,
+    report_repository=_report_repository,
+)
+_content_ingestion_service = ContentIngestionService()
+_submission_preparation_service = SubmissionPreparationService(
+    content_ingestion_service=_content_ingestion_service
+)
+_analysis_service = AnalysisOrchestrationService(
+    agreement_repository=_agreement_repository,
+    report_repository=_report_repository,
+    analysis_execution_strategy=_analysis_execution_strategy,
+    submission_preparation_service=_submission_preparation_service,
+)
 
 
 def get_analysis_service() -> AnalysisOrchestrationService:
@@ -127,7 +136,14 @@ def get_analysis_service() -> AnalysisOrchestrationService:
     return _analysis_service
 
 
+def get_request_rate_limiter() -> RequestRateLimiter:
+    """Return the singleton abuse-protection service used by HTTP middleware."""
+
+    return _request_rate_limiter
+
+
 def get_request_subject(
+    request: Request,
     authorization: str | None = Header(default=None),
 ) -> RequestSubject:
     """Resolve the owner subject from auth headers.
@@ -145,12 +161,17 @@ def get_request_subject(
     extension callers should reuse the same Bearer-token path.
     """
 
-    try:
-        resolved = _request_subject_resolver.resolve(
-            authorization_header=authorization,
-        )
-    except SubjectResolutionError as error:
-        raise HTTPException(status_code=error.status_code, detail=error.detail) from error
+    cached_subject = getattr(request.state, "resolved_subject", None)
+    if isinstance(cached_subject, ResolvedSubject):
+        resolved = cached_subject
+    else:
+        try:
+            resolved = _request_subject_resolver.resolve(
+                authorization_header=authorization,
+            )
+        except SubjectResolutionError as error:
+            raise HTTPException(status_code=error.status_code, detail=error.detail) from error
+        request.state.resolved_subject = resolved
 
     return RequestSubject(
         subject_type=resolved.subject_type,
@@ -168,3 +189,4 @@ def reset_demo_storage() -> None:
     clear_method = getattr(_persistence_storage, "clear", None)
     if callable(clear_method):
         clear_method()
+    _request_rate_limiter.clear()

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -17,14 +17,18 @@ from ..core.config import settings
 from ..repositories.in_memory import (
     InMemoryAgreementRepository,
     InMemoryReportRepository,
+    InMemoryTrackedPolicyRepository,
     InMemoryStorage,
 )
 from ..services.ai_provider import AnalysisProviderRuntimeConfig, build_analysis_provider
-from ..services.analysis_service import AnalysisOrchestrationService, RequestSubject
+from ..services.analysis_service import AnalysisOrchestrationService
 from ..services.content_ingestion import ContentIngestionService
 from ..services.analysis_execution import build_analysis_execution_strategy
 from ..security import RequestRateLimiter, build_default_rate_limit_policies
+from ..services.request_subject import RequestSubject
 from ..services.submission_preparation import SubmissionPreparationService
+from ..services.tracked_policy_service import TrackedPolicyService
+from ..services.web_source import PublicWebSourceInspector
 
 
 def _build_persistence_dependencies():
@@ -41,6 +45,7 @@ def _build_persistence_dependencies():
         from ..persistence.postgres import (  # Imported lazily to keep memory-mode lightweight.
             PostgresAgreementRepository,
             PostgresReportRepository,
+            PostgresTrackedPolicyRepository,
             PostgresStorage,
         )
 
@@ -50,7 +55,8 @@ def _build_persistence_dependencies():
         )
         agreement_repository = PostgresAgreementRepository(storage)
         report_repository = PostgresReportRepository(storage)
-        return agreement_repository, report_repository, storage
+        tracked_policy_repository = PostgresTrackedPolicyRepository(storage)
+        return agreement_repository, report_repository, tracked_policy_repository, storage
 
     if backend not in {"memory", ""}:
         raise RuntimeError(
@@ -60,10 +66,16 @@ def _build_persistence_dependencies():
     storage = InMemoryStorage()
     agreement_repository = InMemoryAgreementRepository(storage)
     report_repository = InMemoryReportRepository(storage)
-    return agreement_repository, report_repository, storage
+    tracked_policy_repository = InMemoryTrackedPolicyRepository(storage)
+    return agreement_repository, report_repository, tracked_policy_repository, storage
 
 
-_agreement_repository, _report_repository, _persistence_storage = _build_persistence_dependencies()
+(
+    _agreement_repository,
+    _report_repository,
+    _tracked_policy_repository,
+    _persistence_storage,
+) = _build_persistence_dependencies()
 
 
 def _build_subject_resolver() -> AuthSubjectResolver:
@@ -122,11 +134,16 @@ _content_ingestion_service = ContentIngestionService()
 _submission_preparation_service = SubmissionPreparationService(
     content_ingestion_service=_content_ingestion_service
 )
+_public_web_source_inspector = PublicWebSourceInspector()
 _analysis_service = AnalysisOrchestrationService(
     agreement_repository=_agreement_repository,
     report_repository=_report_repository,
     analysis_execution_strategy=_analysis_execution_strategy,
     submission_preparation_service=_submission_preparation_service,
+)
+_tracked_policy_service = TrackedPolicyService(
+    tracked_policy_repository=_tracked_policy_repository,
+    public_web_source_inspector=_public_web_source_inspector,
 )
 
 
@@ -134,6 +151,12 @@ def get_analysis_service() -> AnalysisOrchestrationService:
     """Return the singleton orchestration service used by request handlers."""
 
     return _analysis_service
+
+
+def get_tracked_policy_service() -> TrackedPolicyService:
+    """Return the singleton tracked-policy service used by request handlers."""
+
+    return _tracked_policy_service
 
 
 def get_request_rate_limiter() -> RequestRateLimiter:

--- a/backend/app/api/mappers/tracked_policies.py
+++ b/backend/app/api/mappers/tracked_policies.py
@@ -1,0 +1,18 @@
+"""Transport mappers for tracked-policy response payloads."""
+
+from ...repositories.models import StoredTrackedPolicy
+from ...schemas.tracked_policies import TrackedPolicyResponse
+
+
+def to_tracked_policy_response(tracked_policy: StoredTrackedPolicy) -> TrackedPolicyResponse:
+    """Map a persistence tracked-policy model to the API response contract."""
+
+    return TrackedPolicyResponse(
+        id=tracked_policy.id,
+        canonical_url=tracked_policy.canonical_url,
+        display_name=tracked_policy.display_name,
+        source_type=tracked_policy.source_type,
+        tracking_status=tracked_policy.tracking_status.value,
+        last_checked_at=tracked_policy.last_checked_at,
+        created_at=tracked_policy.created_at,
+    )

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -9,7 +9,9 @@ from fastapi import APIRouter
 
 from .routes.agreements import router as agreements_router
 from .routes.reports import router as reports_router
+from .routes.tracked_policies import router as tracked_policies_router
 
 api_router = APIRouter()
 api_router.include_router(agreements_router, tags=["agreements"])
 api_router.include_router(reports_router, tags=["reports"])
+api_router.include_router(tracked_policies_router, tags=["tracked-policies"])

--- a/backend/app/api/routes/agreements.py
+++ b/backend/app/api/routes/agreements.py
@@ -75,5 +75,9 @@ def trigger_manual_analysis(
         report = service.trigger_manual_analysis(subject=subject, agreement_id=agreement_id)
     except AgreementNotFoundError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
+    except InvalidSubmissionError as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(error)
+        ) from error
 
     return to_report_response(report)

--- a/backend/app/api/routes/tracked_policies.py
+++ b/backend/app/api/routes/tracked_policies.py
@@ -1,0 +1,69 @@
+"""HTTP routes for tracked-policy watchlist registration and management."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+
+from ..deps import get_request_subject, get_tracked_policy_service
+from ..mappers.tracked_policies import to_tracked_policy_response
+from ...schemas.tracked_policies import TrackedPolicyCreateRequest, TrackedPolicyResponse
+from ...services.request_subject import RequestSubject
+from ...services.tracked_policy_service import (
+    DuplicateTrackedPolicyError,
+    InvalidTrackedPolicySourceError,
+    TrackedPolicyNotFoundError,
+    TrackedPolicyService,
+)
+
+router = APIRouter(prefix="/tracked-policies")
+
+
+@router.post("", response_model=TrackedPolicyResponse, status_code=status.HTTP_201_CREATED)
+def create_tracked_policy(
+    payload: TrackedPolicyCreateRequest,
+    subject: RequestSubject = Depends(get_request_subject),
+    service: TrackedPolicyService = Depends(get_tracked_policy_service),
+) -> TrackedPolicyResponse:
+    """Register a verified tracked policy URL for the active request subject."""
+
+    try:
+        tracked_policy = service.create_tracked_policy(
+            subject=subject,
+            source_url=payload.source_url,
+        )
+    except InvalidTrackedPolicySourceError as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(error),
+        ) from error
+    except DuplicateTrackedPolicyError as error:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(error)) from error
+
+    return to_tracked_policy_response(tracked_policy)
+
+
+@router.get("", response_model=list[TrackedPolicyResponse])
+def list_tracked_policies(
+    subject: RequestSubject = Depends(get_request_subject),
+    service: TrackedPolicyService = Depends(get_tracked_policy_service),
+) -> list[TrackedPolicyResponse]:
+    """Return active tracked policies for the authenticated request subject."""
+
+    tracked_policies = service.list_tracked_policies(subject=subject)
+    return [to_tracked_policy_response(tracked_policy) for tracked_policy in tracked_policies]
+
+
+@router.delete("/{tracked_policy_id}", status_code=status.HTTP_204_NO_CONTENT)
+def remove_tracked_policy(
+    tracked_policy_id: UUID,
+    subject: RequestSubject = Depends(get_request_subject),
+    service: TrackedPolicyService = Depends(get_tracked_policy_service),
+) -> Response:
+    """Soft-delete one tracked policy for the authenticated request subject."""
+
+    try:
+        service.remove_tracked_policy(subject=subject, tracked_policy_id=tracked_policy_id)
+    except TrackedPolicyNotFoundError as error:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -79,10 +79,14 @@ class Settings:
     )
     analysis_gemini_model: str = os.getenv(
         "ANALYSIS_GEMINI_MODEL",
-        os.getenv("ANALYSIS_AI_MODEL", "gemini-2.0-flash"),
+        os.getenv("ANALYSIS_AI_MODEL", "gemini-2.5-flash"),
     )
     analysis_gemini_base_url: str = os.getenv(
         "ANALYSIS_GEMINI_BASE_URL", "https://generativelanguage.googleapis.com/v1beta"
+    )
+    analysis_gemini_max_input_tokens: int = _env_int("ANALYSIS_GEMINI_MAX_INPUT_TOKENS", "250000")
+    analysis_gemini_estimated_chars_per_token: int = _env_int(
+        "ANALYSIS_GEMINI_ESTIMATED_CHARS_PER_TOKEN", "3"
     )
     analysis_ai_timeout_seconds: float = _env_float("ANALYSIS_AI_TIMEOUT_SECONDS", "20")
     analysis_ai_temperature: float = _env_float("ANALYSIS_AI_TEMPERATURE", "0.1")
@@ -91,6 +95,21 @@ class Settings:
     )
     # Internal execution seam: sync is active now, queued modes can be added later.
     analysis_execution_mode: str = os.getenv("ANALYSIS_EXECUTION_MODE", "sync").lower()
+    # Transport-layer abuse protection defaults.
+    api_rate_limit_requests_per_window: int = _env_int("API_RATE_LIMIT_REQUESTS_PER_WINDOW", "60")
+    api_rate_limit_window_seconds: int = _env_int("API_RATE_LIMIT_WINDOW_SECONDS", "60")
+    agreement_create_rate_limit_requests: int = _env_int(
+        "AGREEMENT_CREATE_RATE_LIMIT_REQUESTS", "10"
+    )
+    agreement_create_rate_limit_window_seconds: int = _env_int(
+        "AGREEMENT_CREATE_RATE_LIMIT_WINDOW_SECONDS", "600"
+    )
+    analysis_rate_limit_requests: int = _env_int("ANALYSIS_RATE_LIMIT_REQUESTS", "5")
+    analysis_rate_limit_window_seconds: int = _env_int("ANALYSIS_RATE_LIMIT_WINDOW_SECONDS", "300")
+    analysis_hourly_rate_limit_requests: int = _env_int("ANALYSIS_HOURLY_RATE_LIMIT_REQUESTS", "20")
+    analysis_hourly_rate_limit_window_seconds: int = _env_int(
+        "ANALYSIS_HOURLY_RATE_LIMIT_WINDOW_SECONDS", "3600"
+    )
     cors_allowed_origins_csv: str = os.getenv(
         "CORS_ALLOWED_ORIGINS",
         "http://localhost:5173,http://127.0.0.1:5173",

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -112,7 +112,7 @@ class Settings:
     )
     cors_allowed_origins_csv: str = os.getenv(
         "CORS_ALLOWED_ORIGINS",
-        "http://localhost:5173,http://127.0.0.1:5173",
+        "http://localhost:5173,http://127.0.0.1:5173,http://localhost:4173,http://127.0.0.1:4173",
     )
 
     @property

--- a/backend/app/core/input_validation.py
+++ b/backend/app/core/input_validation.py
@@ -1,0 +1,186 @@
+"""Shared input validation and sanitization helpers.
+
+Layer: transport/core validation.
+These helpers harden every untrusted string before it reaches persistence,
+remote-fetch logic, or downstream rendering surfaces.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from html import unescape
+import ipaddress
+import re
+import unicodedata
+from urllib.parse import urlsplit, urlunsplit
+
+MAX_TITLE_LENGTH = 200
+MAX_SOURCE_URL_LENGTH = 2048
+MAX_TERMS_TEXT_LENGTH = 200_000
+MAX_TRIGGER_LENGTH = 32
+MAX_EMAIL_LENGTH = 320
+
+_CONTROL_CHARACTER_PATTERN = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_UNSAFE_HTML_BLOCK_PATTERN = re.compile(
+    r"(?is)<(script|style|iframe|object|embed|svg|noscript)[^>]*>.*?</\1>"
+)
+_HTML_TAG_PATTERN = re.compile(r"(?s)<[^>]+>")
+_WHITESPACE_PATTERN = re.compile(r"\s+")
+
+
+def sanitize_single_line_text(
+    value: str,
+    *,
+    field_name: str,
+    max_length: int,
+    min_length: int = 0,
+) -> str:
+    """Return a normalized single-line text value or raise validation error."""
+
+    normalized = normalize_untrusted_text(value)
+    if not normalized:
+        raise ValueError(f"{field_name} cannot be blank.")
+    if len(normalized) < min_length:
+        raise ValueError(f"{field_name} must be at least {min_length} characters.")
+    if len(normalized) > max_length:
+        raise ValueError(f"{field_name} must be {max_length} characters or fewer.")
+    return normalized
+
+
+def sanitize_optional_single_line_text(
+    value: str | None,
+    *,
+    field_name: str,
+    max_length: int,
+) -> str | None:
+    """Normalize optional text values and collapse empty values to None."""
+
+    if value is None:
+        return None
+    normalized = normalize_untrusted_text(value)
+    if not normalized:
+        return None
+    if len(normalized) > max_length:
+        raise ValueError(f"{field_name} must be {max_length} characters or fewer.")
+    return normalized
+
+
+def sanitize_terms_text(value: str, *, min_length: int = 20, max_length: int | None = None) -> str:
+    """Normalize submitted terms text into plain text suitable for storage/analysis."""
+
+    normalized = normalize_untrusted_text(value)
+    if not normalized:
+        raise ValueError("Agreement text cannot be blank.")
+    if len(normalized) < min_length:
+        raise ValueError(f"Agreement text must be at least {min_length} characters.")
+    effective_max_length = max_length or MAX_TERMS_TEXT_LENGTH
+    if len(normalized) > effective_max_length:
+        raise ValueError(f"Agreement text must be {effective_max_length} characters or fewer.")
+    return normalized
+
+
+def sanitize_optional_terms_text(
+    value: str | None,
+    *,
+    min_length: int = 20,
+    max_length: int | None = None,
+) -> str | None:
+    """Normalize optional terms text while preserving missing values."""
+
+    if value is None:
+        return None
+    normalized = normalize_untrusted_text(value)
+    if not normalized:
+        return None
+    return sanitize_terms_text(
+        normalized,
+        min_length=min_length,
+        max_length=max_length,
+    )
+
+
+def validate_external_source_url(value: str) -> str:
+    """Validate a user-submitted source URL for safe server-side fetching."""
+
+    normalized = sanitize_single_line_text(
+        value,
+        field_name="Source URL",
+        max_length=MAX_SOURCE_URL_LENGTH,
+    )
+
+    try:
+        parsed = urlsplit(normalized)
+    except ValueError as error:
+        raise ValueError("Source URL must be a valid absolute URL.") from error
+
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"}:
+        raise ValueError("Source URL must use http or https.")
+    if not parsed.netloc or not parsed.hostname:
+        raise ValueError("Source URL must include a hostname.")
+    if parsed.username or parsed.password:
+        raise ValueError("Source URL cannot include embedded credentials.")
+    if _is_disallowed_hostname(parsed.hostname):
+        raise ValueError("Source URL must target a public hostname.")
+
+    return urlunsplit((scheme, parsed.netloc, parsed.path or "", parsed.query, ""))
+
+
+def validate_agreed_at(value: datetime | None) -> datetime | None:
+    """Reject implausible future agreement timestamps."""
+
+    if value is None:
+        return None
+
+    now = datetime.now(tz=value.tzinfo or timezone.utc)
+    if value > now + timedelta(days=1):
+        raise ValueError("Agreed date cannot be in the future.")
+    return value
+
+
+def sanitize_email_address(value: str) -> str:
+    """Normalize an email address into a strict credential identifier."""
+
+    normalized = sanitize_single_line_text(
+        value,
+        field_name="Email",
+        max_length=MAX_EMAIL_LENGTH,
+    ).lower()
+    if not re.fullmatch(r"[^@\s]+@[^@\s]+\.[^@\s]+", normalized):
+        raise ValueError("Email address is invalid.")
+    return normalized
+
+
+def normalize_untrusted_text(value: str) -> str:
+    """Normalize untrusted text into plain text without enforcing field lengths."""
+
+    normalized = unicodedata.normalize("NFKC", value)
+    normalized = _CONTROL_CHARACTER_PATTERN.sub(" ", normalized)
+    normalized = _UNSAFE_HTML_BLOCK_PATTERN.sub(" ", normalized)
+    normalized = _HTML_TAG_PATTERN.sub(" ", normalized)
+    normalized = unescape(normalized)
+    return _WHITESPACE_PATTERN.sub(" ", normalized).strip()
+
+
+def _is_disallowed_hostname(hostname: str) -> bool:
+    normalized = hostname.strip().rstrip(".").lower()
+    if not normalized:
+        return True
+    if normalized in {"localhost", "0.0.0.0"}:
+        return True
+    if normalized.endswith((".local", ".internal", ".localhost")):
+        return True
+
+    try:
+        address = ipaddress.ip_address(normalized)
+    except ValueError:
+        return False
+
+    return bool(
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,8 +7,11 @@ in route dependencies and services.
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
+from .api.deps import get_request_rate_limiter
 from .api.router import api_router
+from .security import RateLimitExceededError
 from .core.config import settings
 
 
@@ -27,6 +30,31 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    request_rate_limiter = get_request_rate_limiter()
+
+    @app.middleware("http")
+    async def apply_request_rate_limits(request, call_next):
+        try:
+            evaluations = request_rate_limiter.evaluate(request)
+        except RateLimitExceededError as error:
+            response = JSONResponse(
+                status_code=429,
+                content={
+                    "detail": error.detail,
+                    "policy": error.evaluation.policy.name,
+                    "retry_after_seconds": error.evaluation.retry_after_seconds,
+                },
+            )
+            request_rate_limiter.apply_headers(
+                response=response,
+                evaluations=[error.evaluation],
+            )
+            return response
+
+        response = await call_next(request)
+        request_rate_limiter.apply_headers(response=response, evaluations=evaluations)
+        return response
+
     app.include_router(api_router, prefix="/api/v1")
 
     @app.get("/health", tags=["health"])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,7 +21,7 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title="Terms and Conditions Analyzer API",
         version="0.1.0",
-        description="MVP API for terms submission, analysis, and saved report retrieval.",
+        description="MVP API for terms submission, analysis, saved report retrieval, and tracked policy watchlists.",
     )
     app.add_middleware(
         CORSMiddleware,

--- a/backend/app/persistence/postgres.py
+++ b/backend/app/persistence/postgres.py
@@ -11,13 +11,24 @@ import json
 from uuid import UUID, uuid4
 
 import psycopg
+from psycopg import errors as psycopg_errors
 from psycopg.rows import dict_row
 
 from ..repositories.analysis_status import (
     AnalysisLifecycleStatus,
     normalize_analysis_lifecycle_status,
 )
-from ..repositories.models import StoredAgreement, StoredFlaggedClause, StoredReport
+from ..repositories.errors import ActiveTrackedPolicyConflictError
+from ..repositories.models import (
+    StoredAgreement,
+    StoredFlaggedClause,
+    StoredReport,
+    StoredTrackedPolicy,
+)
+from ..repositories.policy_tracking_status import (
+    PolicyTrackingStatus,
+    normalize_policy_tracking_status,
+)
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS agreements (
@@ -55,6 +66,28 @@ CREATE TABLE IF NOT EXISTS reports (
 
 CREATE INDEX IF NOT EXISTS idx_reports_owner_created
   ON reports (subject_type, subject_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS tracked_policies (
+  id UUID PRIMARY KEY,
+  subject_type TEXT NOT NULL,
+  subject_id TEXT NOT NULL,
+  canonical_url TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  source_type TEXT NOT NULL,
+  tracking_status TEXT NOT NULL CHECK (
+    tracking_status IN ('pending_first_snapshot', 'active', 'invalid_source')
+  ),
+  last_checked_at TIMESTAMPTZ NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tracked_policies_owner_created
+  ON tracked_policies (subject_type, subject_id, created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tracked_policies_owner_url_active
+  ON tracked_policies (subject_type, subject_id, canonical_url)
+  WHERE active = TRUE;
 """
 
 
@@ -86,7 +119,7 @@ class PostgresStorage:
 
         with self.connection() as conn:
             with conn.cursor() as cursor:
-                cursor.execute("TRUNCATE TABLE reports, agreements;")
+                cursor.execute("TRUNCATE TABLE reports, agreements, tracked_policies;")
             conn.commit()
 
 
@@ -260,6 +293,149 @@ class PostgresReportRepository:
         return _report_from_row(row) if row else None
 
 
+class PostgresTrackedPolicyRepository:
+    """Postgres implementation of tracked-policy persistence."""
+
+    def __init__(self, storage: PostgresStorage) -> None:
+        self._storage = storage
+
+    def create(
+        self,
+        *,
+        subject_type: str,
+        subject_id: str,
+        canonical_url: str,
+        display_name: str,
+        source_type: str,
+        tracking_status: PolicyTrackingStatus,
+        last_checked_at: datetime | None,
+        active: bool = True,
+    ) -> StoredTrackedPolicy:
+        tracked_policy_id = uuid4()
+        normalized_status = normalize_policy_tracking_status(tracking_status)
+
+        try:
+            with self._storage.connection() as conn:
+                with conn.cursor() as cursor:
+                    cursor.execute(
+                        """
+                        INSERT INTO tracked_policies (
+                          id, subject_type, subject_id, canonical_url, display_name,
+                          source_type, tracking_status, last_checked_at, active
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        RETURNING
+                          id, subject_type, subject_id, canonical_url, display_name,
+                          source_type, tracking_status, last_checked_at, active, created_at;
+                        """,
+                        (
+                            tracked_policy_id,
+                            subject_type,
+                            subject_id,
+                            canonical_url,
+                            display_name,
+                            source_type,
+                            normalized_status.value,
+                            last_checked_at,
+                            active,
+                        ),
+                    )
+                    row = cursor.fetchone()
+                conn.commit()
+        except psycopg_errors.UniqueViolation as error:
+            raise ActiveTrackedPolicyConflictError(
+                "An active tracked policy already exists for this canonical URL."
+            ) from error
+
+        return _tracked_policy_from_row(row)
+
+    def list_active_for_subject(
+        self, *, subject_type: str, subject_id: str
+    ) -> list[StoredTrackedPolicy]:
+        with self._storage.connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT
+                      id, subject_type, subject_id, canonical_url, display_name,
+                      source_type, tracking_status, last_checked_at, active, created_at
+                    FROM tracked_policies
+                    WHERE subject_type = %s AND subject_id = %s AND active = TRUE
+                    ORDER BY created_at DESC;
+                    """,
+                    (subject_type, subject_id),
+                )
+                rows = cursor.fetchall()
+        return [_tracked_policy_from_row(row) for row in rows]
+
+    def get_active_for_subject(
+        self,
+        *,
+        tracked_policy_id: UUID,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicy | None:
+        with self._storage.connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT
+                      id, subject_type, subject_id, canonical_url, display_name,
+                      source_type, tracking_status, last_checked_at, active, created_at
+                    FROM tracked_policies
+                    WHERE id = %s AND subject_type = %s AND subject_id = %s AND active = TRUE;
+                    """,
+                    (tracked_policy_id, subject_type, subject_id),
+                )
+                row = cursor.fetchone()
+        return _tracked_policy_from_row(row) if row else None
+
+    def get_active_by_canonical_url_for_subject(
+        self,
+        *,
+        canonical_url: str,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicy | None:
+        with self._storage.connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT
+                      id, subject_type, subject_id, canonical_url, display_name,
+                      source_type, tracking_status, last_checked_at, active, created_at
+                    FROM tracked_policies
+                    WHERE canonical_url = %s AND subject_type = %s AND subject_id = %s AND active = TRUE;
+                    """,
+                    (canonical_url, subject_type, subject_id),
+                )
+                row = cursor.fetchone()
+        return _tracked_policy_from_row(row) if row else None
+
+    def deactivate_for_subject(
+        self,
+        *,
+        tracked_policy_id: UUID,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicy | None:
+        with self._storage.connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    UPDATE tracked_policies
+                    SET active = FALSE
+                    WHERE id = %s AND subject_type = %s AND subject_id = %s AND active = TRUE
+                    RETURNING
+                      id, subject_type, subject_id, canonical_url, display_name,
+                      source_type, tracking_status, last_checked_at, active, created_at;
+                    """,
+                    (tracked_policy_id, subject_type, subject_id),
+                )
+                row = cursor.fetchone()
+            conn.commit()
+        return _tracked_policy_from_row(row) if row else None
+
+
 def _agreement_from_row(row: dict | None) -> StoredAgreement:
     """Map a DB row dict to `StoredAgreement`."""
 
@@ -308,4 +484,23 @@ def _report_from_row(row: dict | None) -> StoredReport:
         flagged_clauses=flagged_clauses,
         created_at=row["created_at"],
         completed_at=row["completed_at"],
+    )
+
+
+def _tracked_policy_from_row(row: dict | None) -> StoredTrackedPolicy:
+    """Map a DB row dict to `StoredTrackedPolicy`."""
+
+    if row is None:
+        raise ValueError("Tracked policy row cannot be None.")
+    return StoredTrackedPolicy(
+        id=row["id"],
+        subject_type=row["subject_type"],
+        subject_id=row["subject_id"],
+        canonical_url=row["canonical_url"],
+        display_name=row["display_name"],
+        source_type=row["source_type"],
+        tracking_status=normalize_policy_tracking_status(row["tracking_status"]),
+        last_checked_at=row["last_checked_at"],
+        active=row["active"],
+        created_at=row["created_at"],
     )

--- a/backend/app/repositories/errors.py
+++ b/backend/app/repositories/errors.py
@@ -1,0 +1,5 @@
+"""Repository-layer exceptions shared by persistence implementations."""
+
+
+class ActiveTrackedPolicyConflictError(Exception):
+    """Raised when an active tracked policy already exists for the owner/url key."""

--- a/backend/app/repositories/in_memory.py
+++ b/backend/app/repositories/in_memory.py
@@ -5,10 +5,12 @@ when a Supabase/Postgres implementation is introduced.
 """
 
 from datetime import datetime, timezone
+from dataclasses import replace
 from uuid import UUID, uuid4
 
 from .analysis_status import AnalysisLifecycleStatus, normalize_analysis_lifecycle_status
-from .models import StoredAgreement, StoredFlaggedClause, StoredReport
+from .models import StoredAgreement, StoredFlaggedClause, StoredReport, StoredTrackedPolicy
+from .policy_tracking_status import PolicyTrackingStatus, normalize_policy_tracking_status
 
 
 class InMemoryStorage:
@@ -17,10 +19,12 @@ class InMemoryStorage:
     def __init__(self) -> None:
         self.agreements: dict[UUID, StoredAgreement] = {}
         self.reports: dict[UUID, StoredReport] = {}
+        self.tracked_policies: dict[UUID, StoredTrackedPolicy] = {}
 
     def clear(self) -> None:
         self.agreements.clear()
         self.reports.clear()
+        self.tracked_policies.clear()
 
 
 class InMemoryAgreementRepository:
@@ -130,3 +134,102 @@ class InMemoryReportRepository:
         if report.subject_type != subject_type or report.subject_id != subject_id:
             return None
         return report
+
+
+class InMemoryTrackedPolicyRepository:
+    """In-memory tracked-policy repository implementation."""
+
+    def __init__(self, storage: InMemoryStorage) -> None:
+        self._storage = storage
+
+    def create(
+        self,
+        *,
+        subject_type: str,
+        subject_id: str,
+        canonical_url: str,
+        display_name: str,
+        source_type: str,
+        tracking_status: PolicyTrackingStatus,
+        last_checked_at: datetime | None,
+        active: bool = True,
+    ) -> StoredTrackedPolicy:
+        tracked_policy = StoredTrackedPolicy(
+            id=uuid4(),
+            subject_type=subject_type,
+            subject_id=subject_id,
+            canonical_url=canonical_url,
+            display_name=display_name,
+            source_type=source_type,
+            tracking_status=normalize_policy_tracking_status(tracking_status),
+            last_checked_at=last_checked_at,
+            active=active,
+            created_at=datetime.now(timezone.utc),
+        )
+        self._storage.tracked_policies[tracked_policy.id] = tracked_policy
+        return tracked_policy
+
+    def list_active_for_subject(
+        self, *, subject_type: str, subject_id: str
+    ) -> list[StoredTrackedPolicy]:
+        tracked_policies = [
+            tracked_policy
+            for tracked_policy in self._storage.tracked_policies.values()
+            if tracked_policy.subject_type == subject_type
+            and tracked_policy.subject_id == subject_id
+            and tracked_policy.active
+        ]
+        return sorted(
+            tracked_policies,
+            key=lambda tracked_policy: tracked_policy.created_at,
+            reverse=True,
+        )
+
+    def get_active_for_subject(
+        self,
+        *,
+        tracked_policy_id: UUID,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicy | None:
+        tracked_policy = self._storage.tracked_policies.get(tracked_policy_id)
+        if tracked_policy is None or not tracked_policy.active:
+            return None
+        if tracked_policy.subject_type != subject_type or tracked_policy.subject_id != subject_id:
+            return None
+        return tracked_policy
+
+    def get_active_by_canonical_url_for_subject(
+        self,
+        *,
+        canonical_url: str,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicy | None:
+        for tracked_policy in self._storage.tracked_policies.values():
+            if (
+                tracked_policy.subject_type == subject_type
+                and tracked_policy.subject_id == subject_id
+                and tracked_policy.canonical_url == canonical_url
+                and tracked_policy.active
+            ):
+                return tracked_policy
+        return None
+
+    def deactivate_for_subject(
+        self,
+        *,
+        tracked_policy_id: UUID,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicy | None:
+        tracked_policy = self.get_active_for_subject(
+            tracked_policy_id=tracked_policy_id,
+            subject_type=subject_type,
+            subject_id=subject_id,
+        )
+        if tracked_policy is None:
+            return None
+        deactivated_policy = replace(tracked_policy, active=False)
+        self._storage.tracked_policies[tracked_policy_id] = deactivated_policy
+        return deactivated_policy

--- a/backend/app/repositories/interfaces.py
+++ b/backend/app/repositories/interfaces.py
@@ -10,7 +10,8 @@ from typing import Protocol
 from uuid import UUID
 
 from .analysis_status import AnalysisLifecycleStatus
-from .models import StoredAgreement, StoredFlaggedClause, StoredReport
+from .models import StoredAgreement, StoredFlaggedClause, StoredReport, StoredTrackedPolicy
+from .policy_tracking_status import PolicyTrackingStatus
 
 
 class AgreementRepository(Protocol):
@@ -65,3 +66,48 @@ class ReportRepository(Protocol):
         subject_type: str,
         subject_id: str,
     ) -> StoredReport | None: ...
+
+
+class TrackedPolicyRepository(Protocol):
+    """Persistence operations for active/inactive tracked policy watchlist rows."""
+
+    def create(
+        self,
+        *,
+        subject_type: str,
+        subject_id: str,
+        canonical_url: str,
+        display_name: str,
+        source_type: str,
+        tracking_status: PolicyTrackingStatus,
+        last_checked_at: datetime | None,
+        active: bool = True,
+    ) -> StoredTrackedPolicy: ...
+
+    def list_active_for_subject(
+        self, *, subject_type: str, subject_id: str
+    ) -> list[StoredTrackedPolicy]: ...
+
+    def get_active_for_subject(
+        self,
+        *,
+        tracked_policy_id: UUID,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicy | None: ...
+
+    def get_active_by_canonical_url_for_subject(
+        self,
+        *,
+        canonical_url: str,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicy | None: ...
+
+    def deactivate_for_subject(
+        self,
+        *,
+        tracked_policy_id: UUID,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicy | None: ...

--- a/backend/app/repositories/models.py
+++ b/backend/app/repositories/models.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from uuid import UUID
 
 from .analysis_status import AnalysisLifecycleStatus
+from .policy_tracking_status import PolicyTrackingStatus
 
 
 @dataclass(frozen=True)
@@ -54,3 +55,19 @@ class StoredReport:
     flagged_clauses: list[StoredFlaggedClause]
     created_at: datetime
     completed_at: datetime | None
+
+
+@dataclass(frozen=True)
+class StoredTrackedPolicy:
+    """Persisted watchlist entry for an authenticated user's tracked policy URL."""
+
+    id: UUID
+    subject_type: str
+    subject_id: str
+    canonical_url: str
+    display_name: str
+    source_type: str
+    tracking_status: PolicyTrackingStatus
+    last_checked_at: datetime | None
+    active: bool
+    created_at: datetime

--- a/backend/app/repositories/policy_tracking_status.py
+++ b/backend/app/repositories/policy_tracking_status.py
@@ -1,0 +1,28 @@
+"""Internal tracked-policy lifecycle status model.
+
+These values describe watchlist registration and later background-processing
+state. The current story only persists `pending_first_snapshot`, but the enum
+already reserves future states so the transport and persistence seams do not
+need churn when snapshot processing is added.
+"""
+
+from enum import Enum
+
+
+class PolicyTrackingStatus(str, Enum):
+    """Lifecycle states for tracked-policy rows."""
+
+    PENDING_FIRST_SNAPSHOT = "pending_first_snapshot"
+    ACTIVE = "active"
+    INVALID_SOURCE = "invalid_source"
+
+
+def normalize_policy_tracking_status(value: PolicyTrackingStatus | str) -> PolicyTrackingStatus:
+    """Return a normalized tracking status enum or raise for unknown values."""
+
+    if isinstance(value, PolicyTrackingStatus):
+        return value
+    try:
+        return PolicyTrackingStatus(str(value))
+    except ValueError as error:
+        raise ValueError(f"Unsupported policy tracking status: {value}") from error

--- a/backend/app/schemas/agreements.py
+++ b/backend/app/schemas/agreements.py
@@ -8,20 +8,63 @@ or extension-triggered analysis workflows.
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
+
+from ..core.input_validation import (
+    MAX_SOURCE_URL_LENGTH,
+    MAX_TERMS_TEXT_LENGTH,
+    MAX_TITLE_LENGTH,
+    sanitize_optional_single_line_text,
+    sanitize_terms_text,
+    validate_agreed_at,
+    validate_external_source_url,
+)
 
 
 class AgreementCreateRequest(BaseModel):
     """Request payload for creating a persisted agreement record."""
 
-    title: str | None = Field(default=None, max_length=200)
-    source_url: str | None = Field(default=None, max_length=2048)
+    model_config = ConfigDict(extra="forbid")
+
+    title: StrictStr | None = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    source_url: StrictStr | None = Field(default=None, max_length=MAX_SOURCE_URL_LENGTH)
     agreed_at: datetime | None = None
-    terms_text: str = Field(min_length=20)
+    terms_text: StrictStr = Field(min_length=20, max_length=MAX_TERMS_TEXT_LENGTH)
+
+    @field_validator("title")
+    @classmethod
+    def sanitize_title(cls, value: str | None) -> str | None:
+        return sanitize_optional_single_line_text(
+            value,
+            field_name="Title",
+            max_length=MAX_TITLE_LENGTH,
+        )
+
+    @field_validator("source_url")
+    @classmethod
+    def sanitize_source_url(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return validate_external_source_url(value)
+
+    @field_validator("agreed_at")
+    @classmethod
+    def validate_agreed_at_value(cls, value: datetime | None) -> datetime | None:
+        return validate_agreed_at(value)
+
+    @field_validator("terms_text")
+    @classmethod
+    def sanitize_terms_text_value(cls, value: str) -> str:
+        return sanitize_terms_text(
+            value,
+            max_length=MAX_TERMS_TEXT_LENGTH,
+        )
 
 
 class AgreementResponse(BaseModel):
     """Serialized agreement payload returned after creation."""
+
+    model_config = ConfigDict(extra="forbid")
 
     id: UUID
     title: str | None

--- a/backend/app/schemas/reports.py
+++ b/backend/app/schemas/reports.py
@@ -7,22 +7,76 @@ These models define the API contract consumed by the dashboard client.
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator, model_validator
+
+from ..core.input_validation import (
+    MAX_SOURCE_URL_LENGTH,
+    MAX_TERMS_TEXT_LENGTH,
+    MAX_TITLE_LENGTH,
+    MAX_TRIGGER_LENGTH,
+    sanitize_optional_single_line_text,
+    sanitize_optional_terms_text,
+    sanitize_single_line_text,
+    validate_agreed_at,
+    validate_external_source_url,
+)
 
 
 class AnalysisTriggerRequest(BaseModel):
     """Request body for manual analysis trigger endpoint."""
 
-    trigger: str = Field(default="manual")
+    model_config = ConfigDict(extra="forbid")
+
+    trigger: StrictStr = Field(default="manual", max_length=MAX_TRIGGER_LENGTH)
+
+    @field_validator("trigger")
+    @classmethod
+    def validate_trigger(cls, value: str) -> str:
+        return sanitize_single_line_text(
+            value,
+            field_name="Trigger",
+            max_length=MAX_TRIGGER_LENGTH,
+        )
 
 
 class ReportAnalyzeRequest(BaseModel):
     """Request body for one-shot submit-and-analyze flow."""
 
-    title: str | None = Field(default=None, max_length=200)
-    source_url: str | None = Field(default=None, max_length=2048)
+    model_config = ConfigDict(extra="forbid")
+
+    title: StrictStr | None = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    source_url: StrictStr | None = Field(default=None, max_length=MAX_SOURCE_URL_LENGTH)
     agreed_at: datetime | None = None
-    terms_text: str | None = None
+    terms_text: StrictStr | None = Field(default=None, max_length=MAX_TERMS_TEXT_LENGTH)
+
+    @field_validator("title")
+    @classmethod
+    def sanitize_title(cls, value: str | None) -> str | None:
+        return sanitize_optional_single_line_text(
+            value,
+            field_name="Title",
+            max_length=MAX_TITLE_LENGTH,
+        )
+
+    @field_validator("source_url")
+    @classmethod
+    def sanitize_source_url(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return validate_external_source_url(value)
+
+    @field_validator("terms_text")
+    @classmethod
+    def sanitize_terms_text_value(cls, value: str | None) -> str | None:
+        return sanitize_optional_terms_text(
+            value,
+            max_length=MAX_TERMS_TEXT_LENGTH,
+        )
+
+    @field_validator("agreed_at")
+    @classmethod
+    def validate_agreed_at_value(cls, value: datetime | None) -> datetime | None:
+        return validate_agreed_at(value)
 
     @model_validator(mode="after")
     def validate_input(self) -> "ReportAnalyzeRequest":
@@ -38,6 +92,8 @@ class ReportAnalyzeRequest(BaseModel):
 class FlaggedClauseResponse(BaseModel):
     """Serialized flagged clause entry returned to clients."""
 
+    model_config = ConfigDict(extra="forbid")
+
     clause_type: str
     severity: str
     excerpt: str
@@ -46,6 +102,8 @@ class FlaggedClauseResponse(BaseModel):
 
 class ReportResponse(BaseModel):
     """Full report payload for detail views and immediate analyze responses."""
+
+    model_config = ConfigDict(extra="forbid")
 
     id: UUID
     agreement_id: UUID
@@ -63,6 +121,8 @@ class ReportResponse(BaseModel):
 
 class ReportListItemResponse(BaseModel):
     """Compact report payload for history listings."""
+
+    model_config = ConfigDict(extra="forbid")
 
     id: UUID
     agreement_id: UUID

--- a/backend/app/schemas/tracked_policies.py
+++ b/backend/app/schemas/tracked_policies.py
@@ -1,0 +1,35 @@
+"""Pydantic request/response contracts for tracked-policy watchlist endpoints."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
+
+from ..core.input_validation import MAX_SOURCE_URL_LENGTH, validate_external_source_url
+
+
+class TrackedPolicyCreateRequest(BaseModel):
+    """Request payload for registering a new tracked policy URL."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source_url: StrictStr = Field(max_length=MAX_SOURCE_URL_LENGTH)
+
+    @field_validator("source_url")
+    @classmethod
+    def sanitize_source_url(cls, value: str) -> str:
+        return validate_external_source_url(value)
+
+
+class TrackedPolicyResponse(BaseModel):
+    """Serialized tracked-policy payload returned to dashboard clients."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: UUID
+    canonical_url: str
+    display_name: str
+    source_type: str
+    tracking_status: str
+    last_checked_at: datetime | None
+    created_at: datetime

--- a/backend/app/security/__init__.py
+++ b/backend/app/security/__init__.py
@@ -1,0 +1,17 @@
+"""Security boundaries for transport-layer abuse protection."""
+
+from .rate_limit import (
+    RateLimitExceededError,
+    RateLimitPolicy,
+    RateLimitEvaluation,
+    RequestRateLimiter,
+    build_default_rate_limit_policies,
+)
+
+__all__ = [
+    "RateLimitExceededError",
+    "RateLimitPolicy",
+    "RateLimitEvaluation",
+    "RequestRateLimiter",
+    "build_default_rate_limit_policies",
+]

--- a/backend/app/security/rate_limit.py
+++ b/backend/app/security/rate_limit.py
@@ -1,0 +1,350 @@
+"""Transport-layer abuse protection and request throttling.
+
+Layer: transport/security.
+This module applies coarse request-rate protection before business handlers run.
+It keeps abuse controls out of routes/services while still letting the app use
+verified subject identity for user-scoped limits on expensive endpoints.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from math import ceil
+import re
+from threading import Lock
+import time
+from typing import Callable, Iterable, Literal, Pattern
+
+from fastapi import Request
+from starlette.responses import Response
+
+from ..auth.subject_resolver import AuthSubjectResolver, ResolvedSubject, SubjectResolutionError
+
+RateLimitKeyStrategy = Literal["ip", "subject_or_ip"]
+
+
+@dataclass(frozen=True)
+class RateLimitPolicy:
+    """Static policy definition for one protected request class."""
+
+    name: str
+    request_limit: int
+    window_seconds: int
+    methods: frozenset[str]
+    path_pattern: Pattern[str]
+    key_strategy: RateLimitKeyStrategy
+
+    def matches(self, *, method: str, path: str) -> bool:
+        """Return True when this policy applies to the incoming request."""
+
+        normalized_method = method.upper()
+        return normalized_method in self.methods and bool(self.path_pattern.match(path))
+
+
+@dataclass(frozen=True)
+class RateLimitEvaluation:
+    """Result of consuming one request against a single policy bucket."""
+
+    policy: RateLimitPolicy
+    allowed: bool
+    limit: int
+    remaining: int
+    reset_after_seconds: int
+    retry_after_seconds: int | None
+
+    @property
+    def header_values(self) -> dict[str, str]:
+        """Serialize response headers describing the active policy state."""
+
+        headers = {
+            "X-RateLimit-Limit": str(self.limit),
+            "X-RateLimit-Remaining": str(self.remaining),
+            "X-RateLimit-Reset": str(self.reset_after_seconds),
+            "X-RateLimit-Policy": self.policy.name,
+        }
+        if self.retry_after_seconds is not None:
+            headers["Retry-After"] = str(self.retry_after_seconds)
+        return headers
+
+
+@dataclass(frozen=True)
+class _StoreConsumption:
+    allowed: bool
+    limit: int
+    remaining: int
+    reset_after_seconds: int
+    retry_after_seconds: int | None
+
+
+class RateLimitExceededError(Exception):
+    """Raised when one policy denies the request."""
+
+    def __init__(self, evaluation: RateLimitEvaluation) -> None:
+        super().__init__(evaluation.policy.name)
+        self.evaluation = evaluation
+
+    @property
+    def detail(self) -> str:
+        retry_after_seconds = self.evaluation.retry_after_seconds or 1
+        return (
+            f"Rate limit exceeded for {self.evaluation.policy.name}. "
+            f"Retry in {retry_after_seconds} seconds."
+        )
+
+
+class SlidingWindowRateLimitStore:
+    """In-process sliding-window counter store.
+
+    This is intentionally process-local for the current single-service MVP.
+    The limiter contract is designed so a Redis-backed store can replace this
+    later without changing route or middleware wiring.
+    """
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._buckets: dict[str, deque[float]] = {}
+
+    def consume(
+        self,
+        *,
+        bucket_key: str,
+        request_limit: int,
+        window_seconds: int,
+    ) -> _StoreConsumption:
+        """Record one request and return the remaining budget for the bucket."""
+
+        now = time.monotonic()
+        window_start = now - window_seconds
+
+        with self._lock:
+            bucket = self._buckets.setdefault(bucket_key, deque())
+            while bucket and bucket[0] <= window_start:
+                bucket.popleft()
+
+            if len(bucket) >= request_limit:
+                retry_after_seconds = max(1, ceil(window_seconds - (now - bucket[0])))
+                return _StoreConsumption(
+                    allowed=False,
+                    limit=request_limit,
+                    remaining=0,
+                    reset_after_seconds=retry_after_seconds,
+                    retry_after_seconds=retry_after_seconds,
+                )
+
+            bucket.append(now)
+            reset_after_seconds = max(1, ceil(window_seconds - (now - bucket[0])))
+            return _StoreConsumption(
+                allowed=True,
+                limit=request_limit,
+                remaining=max(0, request_limit - len(bucket)),
+                reset_after_seconds=reset_after_seconds,
+                retry_after_seconds=None,
+            )
+
+    def clear(self) -> None:
+        """Reset all buckets. Used by tests and local demo resets."""
+
+        with self._lock:
+            self._buckets.clear()
+
+
+class RequestRateLimiter:
+    """Evaluate request policies and attach response metadata."""
+
+    def __init__(
+        self,
+        *,
+        policies: Iterable[RateLimitPolicy],
+        subject_resolver_provider: Callable[[], AuthSubjectResolver] | None = None,
+        store: SlidingWindowRateLimitStore | None = None,
+    ) -> None:
+        self._policies = tuple(policies)
+        self._subject_resolver_provider = subject_resolver_provider
+        self._store = store or SlidingWindowRateLimitStore()
+
+    def evaluate(self, request: Request) -> list[RateLimitEvaluation]:
+        """Consume all matching policy buckets for the request or raise 429."""
+
+        matching_policies = [
+            policy
+            for policy in self._policies
+            if policy.request_limit > 0
+            and policy.window_seconds > 0
+            and policy.matches(method=request.method, path=request.url.path)
+        ]
+        if not matching_policies:
+            return []
+
+        resolved_subject = self._resolve_subject_if_available(request)
+        client_ip = resolve_client_ip(request)
+        evaluations: list[RateLimitEvaluation] = []
+
+        for policy in matching_policies:
+            bucket_key = self._build_bucket_key(
+                policy=policy,
+                client_ip=client_ip,
+                resolved_subject=resolved_subject,
+            )
+            consumption = self._store.consume(
+                bucket_key=bucket_key,
+                request_limit=policy.request_limit,
+                window_seconds=policy.window_seconds,
+            )
+            evaluation = RateLimitEvaluation(
+                policy=policy,
+                allowed=consumption.allowed,
+                limit=consumption.limit,
+                remaining=consumption.remaining,
+                reset_after_seconds=consumption.reset_after_seconds,
+                retry_after_seconds=consumption.retry_after_seconds,
+            )
+            evaluations.append(evaluation)
+            if not evaluation.allowed:
+                raise RateLimitExceededError(evaluation)
+
+        return evaluations
+
+    def apply_headers(
+        self,
+        *,
+        response: Response,
+        evaluations: Iterable[RateLimitEvaluation],
+    ) -> None:
+        """Attach the closest-to-exhausted policy headers to the response."""
+
+        selected = self._select_response_evaluation(evaluations)
+        if not selected:
+            return
+
+        for key, value in selected.header_values.items():
+            response.headers[key] = value
+
+    def clear(self) -> None:
+        """Reset limiter state."""
+
+        self._store.clear()
+
+    def _resolve_subject_if_available(self, request: Request) -> ResolvedSubject | None:
+        cached_subject = getattr(request.state, "resolved_subject", None)
+        if isinstance(cached_subject, ResolvedSubject):
+            return cached_subject
+
+        if self._subject_resolver_provider is None:
+            return None
+
+        authorization_header = request.headers.get("authorization")
+        if not authorization_header:
+            return None
+
+        try:
+            resolved_subject = self._subject_resolver_provider().resolve(
+                authorization_header=authorization_header
+            )
+        except SubjectResolutionError:
+            return None
+
+        request.state.resolved_subject = resolved_subject
+        return resolved_subject
+
+    def _build_bucket_key(
+        self,
+        *,
+        policy: RateLimitPolicy,
+        client_ip: str,
+        resolved_subject: ResolvedSubject | None,
+    ) -> str:
+        if policy.key_strategy == "ip":
+            identifier = f"ip:{client_ip}"
+        else:
+            if resolved_subject:
+                identifier = f"subject:{resolved_subject.subject_id}"
+            else:
+                identifier = f"ip:{client_ip}"
+
+        return f"{policy.name}:{identifier}"
+
+    def _select_response_evaluation(
+        self, evaluations: Iterable[RateLimitEvaluation]
+    ) -> RateLimitEvaluation | None:
+        collected = list(evaluations)
+        if not collected:
+            return None
+
+        return min(
+            collected,
+            key=lambda evaluation: (
+                evaluation.remaining,
+                evaluation.reset_after_seconds,
+                evaluation.limit,
+            ),
+        )
+
+
+def resolve_client_ip(request: Request) -> str:
+    """Return the best available client IP from proxy-aware headers."""
+
+    cf_connecting_ip = request.headers.get("cf-connecting-ip", "").strip()
+    if cf_connecting_ip:
+        return cf_connecting_ip
+
+    x_forwarded_for = request.headers.get("x-forwarded-for", "").strip()
+    if x_forwarded_for:
+        forwarded_ip = x_forwarded_for.split(",")[0].strip()
+        if forwarded_ip:
+            return forwarded_ip
+
+    x_real_ip = request.headers.get("x-real-ip", "").strip()
+    if x_real_ip:
+        return x_real_ip
+
+    if request.client and request.client.host:
+        return request.client.host
+
+    return "unknown"
+
+
+def build_default_rate_limit_policies(*, settings: object) -> tuple[RateLimitPolicy, ...]:
+    """Build the default abuse-protection policies from environment settings."""
+
+    api_pattern = re.compile(r"^/api/v1(?:/.*)?$")
+    analysis_pattern = re.compile(r"^/api/v1/reports/analyze$|^/api/v1/agreements/[^/]+/analyses$")
+
+    policies = (
+        RateLimitPolicy(
+            name="api_requests",
+            request_limit=getattr(settings, "api_rate_limit_requests_per_window"),
+            window_seconds=getattr(settings, "api_rate_limit_window_seconds"),
+            methods=frozenset({"GET", "POST"}),
+            path_pattern=api_pattern,
+            key_strategy="ip",
+        ),
+        RateLimitPolicy(
+            name="agreement_creation",
+            request_limit=getattr(settings, "agreement_create_rate_limit_requests"),
+            window_seconds=getattr(settings, "agreement_create_rate_limit_window_seconds"),
+            methods=frozenset({"POST"}),
+            path_pattern=re.compile(r"^/api/v1/agreements$"),
+            key_strategy="subject_or_ip",
+        ),
+        RateLimitPolicy(
+            name="analysis_generation_burst",
+            request_limit=getattr(settings, "analysis_rate_limit_requests"),
+            window_seconds=getattr(settings, "analysis_rate_limit_window_seconds"),
+            methods=frozenset({"POST"}),
+            path_pattern=analysis_pattern,
+            key_strategy="subject_or_ip",
+        ),
+        RateLimitPolicy(
+            name="analysis_generation_hourly",
+            request_limit=getattr(settings, "analysis_hourly_rate_limit_requests"),
+            window_seconds=getattr(settings, "analysis_hourly_rate_limit_window_seconds"),
+            methods=frozenset({"POST"}),
+            path_pattern=analysis_pattern,
+            key_strategy="subject_or_ip",
+        ),
+    )
+
+    return tuple(
+        policy for policy in policies if policy.request_limit > 0 and policy.window_seconds > 0
+    )

--- a/backend/app/services/ai_provider.py
+++ b/backend/app/services/ai_provider.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 import json
 import logging
+from math import ceil
 import re
 from typing import Callable, Mapping, Protocol
 
@@ -27,6 +28,7 @@ __all__ = [
     "AnalysisInputMetadata",
     "AnalysisProviderRuntimeConfig",
     "AnalysisProviderConfigurationError",
+    "AnalysisProviderInputError",
     "AnalysisProviderInvocationError",
     "AnalysisProvider",
     "DeterministicAnalysisProvider",
@@ -40,6 +42,14 @@ __all__ = [
 ]
 
 LOGGER = logging.getLogger(__name__)
+
+# Gemini 2.5 Flash currently advertises a 1,048,576-token context window, but
+# the free Gemini API tier exposes a stricter 250,000 input-tokens-per-minute
+# budget. The default runtime limit below intentionally follows that tighter
+# free-tier budget so one request cannot exceed the available input allowance.
+DEFAULT_GEMINI_25_FLASH_MODEL_NAME = "gemini-2.5-flash"
+DEFAULT_GEMINI_25_FLASH_FREE_TIER_INPUT_TOKEN_LIMIT = 250_000
+DEFAULT_GEMINI_ESTIMATED_CHARS_PER_TOKEN = 3
 
 
 @dataclass(frozen=True)
@@ -127,12 +137,18 @@ class AnalysisProviderRuntimeConfig:
     openai_compatible_model_name: str = ""
     openai_compatible_base_url: str = "https://api.openai.com/v1"
     gemini_api_key: str = ""
-    gemini_model_name: str = "gemini-2.0-flash"
+    gemini_model_name: str = DEFAULT_GEMINI_25_FLASH_MODEL_NAME
     gemini_base_url: str = "https://generativelanguage.googleapis.com/v1beta"
+    gemini_max_input_tokens: int = DEFAULT_GEMINI_25_FLASH_FREE_TIER_INPUT_TOKEN_LIMIT
+    gemini_estimated_chars_per_token: int = DEFAULT_GEMINI_ESTIMATED_CHARS_PER_TOKEN
 
 
 class AnalysisProviderConfigurationError(Exception):
     """Raised when runtime config is insufficient for selected provider."""
+
+
+class AnalysisProviderInputError(Exception):
+    """Raised when normalized submission input cannot be sent safely to the provider."""
 
 
 class AnalysisProviderInvocationError(Exception):
@@ -160,6 +176,8 @@ class FallbackAnalysisProvider:
     def analyze(self, *, analysis_input: AnalysisInput) -> ProviderAnalysisResult:
         try:
             return self._primary.analyze(analysis_input=analysis_input)
+        except AnalysisProviderInputError:
+            raise
         except Exception as error:
             fallback_result = self._fallback.analyze(analysis_input=analysis_input)
             warning = (
@@ -213,7 +231,7 @@ class OpenAICompatibleAnalysisProvider:
         self, *, analysis_input: AnalysisInput
     ) -> _AIProviderInvocationResult:
         endpoint = f"{self._base_url}/chat/completions"
-        user_payload = _build_provider_user_payload(analysis_input)
+        prompt_text = _build_provider_prompt_text(analysis_input)
 
         try:
             response = httpx.post(
@@ -231,10 +249,7 @@ class OpenAICompatibleAnalysisProvider:
                         {"role": "system", "content": self._SYSTEM_PROMPT},
                         {
                             "role": "user",
-                            "content": (
-                                "Analyze this submission payload and return JSON only:\n"
-                                f"{json.dumps(user_payload)}"
-                            ),
+                            "content": prompt_text,
                         },
                     ],
                 },
@@ -294,12 +309,16 @@ class GeminiAnalysisProvider:
         base_url: str,
         timeout_seconds: float,
         temperature: float,
+        max_input_tokens: int,
+        estimated_chars_per_token: int,
     ) -> None:
         self._api_key = api_key
         self._model_name = model_name
         self._base_url = base_url.rstrip("/")
         self._timeout_seconds = timeout_seconds
         self._temperature = temperature
+        self._max_input_tokens = max_input_tokens
+        self._estimated_chars_per_token = estimated_chars_per_token
 
     def analyze(self, *, analysis_input: AnalysisInput) -> ProviderAnalysisResult:
         invocation = self._invoke_generate_content(analysis_input=analysis_input)
@@ -313,7 +332,17 @@ class GeminiAnalysisProvider:
         self, *, analysis_input: AnalysisInput
     ) -> _AIProviderInvocationResult:
         endpoint = f"{self._base_url}/models/{self._model_name}:generateContent?key={self._api_key}"
-        user_payload = _build_provider_user_payload(analysis_input)
+        prompt_text = _build_provider_prompt_text(analysis_input)
+        estimated_input_tokens = _estimate_prompt_token_count(
+            system_prompt=self._SYSTEM_PROMPT,
+            prompt_text=prompt_text,
+            estimated_chars_per_token=self._estimated_chars_per_token,
+        )
+        _ensure_prompt_within_token_budget(
+            model_name=self._model_name,
+            estimated_input_tokens=estimated_input_tokens,
+            max_input_tokens=self._max_input_tokens,
+        )
 
         try:
             response = httpx.post(
@@ -325,14 +354,7 @@ class GeminiAnalysisProvider:
                     "contents": [
                         {
                             "role": "user",
-                            "parts": [
-                                {
-                                    "text": (
-                                        "Analyze this submission payload and return JSON only:\n"
-                                        f"{json.dumps(user_payload)}"
-                                    )
-                                }
-                            ],
+                            "parts": [{"text": prompt_text}],
                         }
                     ],
                     "generationConfig": {
@@ -379,6 +401,8 @@ class GeminiAnalysisProvider:
             response_content=content,
             attributes={
                 "analysis_mode": "gemini_generate_content_json",
+                "estimated_input_tokens": str(estimated_input_tokens),
+                "max_input_tokens": str(self._max_input_tokens),
                 "finish_reason": str(finish_reason) if finish_reason is not None else "unknown",
             },
         )
@@ -602,6 +626,59 @@ def _build_provider_user_payload(analysis_input: AnalysisInput) -> dict:
     }
 
 
+def _build_provider_prompt_text(analysis_input: AnalysisInput) -> str:
+    """Return the exact user prompt text sent to AI providers."""
+
+    return (
+        "Analyze this submission payload and return JSON only:\n"
+        f"{json.dumps(_build_provider_user_payload(analysis_input), ensure_ascii=False)}"
+    )
+
+
+def _estimate_prompt_token_count(
+    *,
+    system_prompt: str,
+    prompt_text: str,
+    estimated_chars_per_token: int,
+) -> int:
+    """Estimate prompt token count from serialized prompt text.
+
+    The estimator is intentionally conservative. Using 3 chars/token produces a
+    higher token estimate than typical English prose, which gives Gemini free
+    tier requests headroom without requiring an extra network round-trip to
+    `countTokens`.
+    """
+
+    if estimated_chars_per_token <= 0:
+        raise AnalysisProviderConfigurationError(
+            "Gemini estimated chars-per-token must be greater than zero."
+        )
+    prompt_characters = len(system_prompt) + len(prompt_text)
+    return ceil(prompt_characters / estimated_chars_per_token)
+
+
+def _ensure_prompt_within_token_budget(
+    *,
+    model_name: str,
+    estimated_input_tokens: int,
+    max_input_tokens: int,
+) -> None:
+    """Reject prompts that exceed the configured Gemini input budget."""
+
+    if max_input_tokens <= 0:
+        raise AnalysisProviderConfigurationError(
+            "Gemini max input tokens must be greater than zero."
+        )
+    if estimated_input_tokens <= max_input_tokens:
+        return
+    raise AnalysisProviderInputError(
+        "Submission is too large for Gemini analysis. "
+        f"Estimated prompt size {estimated_input_tokens:,} input tokens exceeds the "
+        f"configured {model_name} limit of {max_input_tokens:,}. "
+        "Shorten the submitted terms text and try again."
+    )
+
+
 def _extract_text_from_provider_content(content: object) -> str:
     """Extract text from provider content shapes (string or parts list)."""
 
@@ -798,6 +875,8 @@ def _build_gemini_provider(config: AnalysisProviderRuntimeConfig) -> AnalysisPro
         base_url=config.gemini_base_url,
         timeout_seconds=config.ai_timeout_seconds,
         temperature=config.ai_temperature,
+        max_input_tokens=config.gemini_max_input_tokens,
+        estimated_chars_per_token=config.gemini_estimated_chars_per_token,
     )
 
 

--- a/backend/app/services/analysis_service.py
+++ b/backend/app/services/analysis_service.py
@@ -26,6 +26,7 @@ from uuid import UUID
 
 from ..repositories.interfaces import AgreementRepository, ReportRepository
 from ..repositories.models import StoredAgreement, StoredReport
+from .ai_provider import AnalysisProviderInputError
 from .analysis_execution import AnalysisExecutionRequest, AnalysisExecutionStrategy
 from .extraction_contracts import ExtractionIngestionResult
 from .submission_preparation import (
@@ -199,11 +200,14 @@ class AnalysisOrchestrationService:
         details and persistence timing.
         """
 
-        return self._analysis_execution_strategy.execute(
-            request=AnalysisExecutionRequest(
-                subject_type=subject.subject_type,
-                subject_id=subject.subject_id,
-                agreement=agreement,
-                ingestion_result=ingestion_result,
+        try:
+            return self._analysis_execution_strategy.execute(
+                request=AnalysisExecutionRequest(
+                    subject_type=subject.subject_type,
+                    subject_id=subject.subject_id,
+                    agreement=agreement,
+                    ingestion_result=ingestion_result,
+                )
             )
-        )
+        except AnalysisProviderInputError as error:
+            raise InvalidSubmissionError(str(error)) from error

--- a/backend/app/services/analysis_service.py
+++ b/backend/app/services/analysis_service.py
@@ -26,6 +26,7 @@ from uuid import UUID
 
 from ..repositories.interfaces import AgreementRepository, ReportRepository
 from ..repositories.models import StoredAgreement, StoredReport
+from .request_subject import RequestSubject
 from .ai_provider import AnalysisProviderInputError
 from .analysis_execution import AnalysisExecutionRequest, AnalysisExecutionStrategy
 from .extraction_contracts import ExtractionIngestionResult
@@ -43,14 +44,6 @@ __all__ = [
     "ReportNotFoundError",
     "RequestSubject",
 ]
-
-
-@dataclass(frozen=True)
-class RequestSubject:
-    """Identity tuple used for owner-scoped data access."""
-
-    subject_type: str
-    subject_id: str
 
 
 class AgreementNotFoundError(Exception):

--- a/backend/app/services/content_ingestion.py
+++ b/backend/app/services/content_ingestion.py
@@ -26,6 +26,7 @@ from urllib.parse import urlparse
 
 import httpx
 
+from ..core.input_validation import normalize_untrusted_text, validate_external_source_url
 from .extraction_contracts import (
     ExtractionIngestionRequest,
     ExtractionIngestionResult,
@@ -76,12 +77,13 @@ class HttpxUrlContentFetcher:
     def fetch(self, *, url: str) -> UrlFetchPayload:
         """Fetch URL content and return body text plus response content type."""
 
-        parsed = urlparse(url)
+        safe_url = validate_external_source_url(url)
+        parsed = urlparse(safe_url)
         if parsed.scheme not in {"http", "https"}:
             raise ContentIngestionError("URL ingestion supports only http/https sources.")
 
         response = httpx.get(
-            url,
+            safe_url,
             follow_redirects=True,
             timeout=self._timeout_seconds,
             headers={
@@ -121,7 +123,7 @@ class SimpleFetchedContentExtractor:
         return self._normalize_text(unescape(without_tags))
 
     def _normalize_text(self, value: str) -> str:
-        return re.sub(r"\s+", " ", value).strip()
+        return normalize_untrusted_text(value)
 
     def _looks_like_html(self, text: str) -> bool:
         lowered = text.lower()

--- a/backend/app/services/content_ingestion.py
+++ b/backend/app/services/content_ingestion.py
@@ -18,116 +18,33 @@ Upgrade seam:
   orchestration or route contracts.
 """
 
-from dataclasses import dataclass
-from html import unescape
 import re
-from typing import Protocol
-from urllib.parse import urlparse
 
 import httpx
 
-from ..core.input_validation import normalize_untrusted_text, validate_external_source_url
 from .extraction_contracts import (
     ExtractionIngestionRequest,
     ExtractionIngestionResult,
     ExtractionMetadata,
     ExtractionSourceKind,
 )
+from .web_source import (
+    DEFAULT_WEB_SOURCE_TIMEOUT_SECONDS,
+    FetchedContentExtractor,
+    HttpxUrlContentFetcher,
+    SimpleFetchedContentExtractor,
+    UrlContentFetcher,
+    UrlFetchPayload,
+)
 
 MIN_ANALYZABLE_TEXT_LENGTH = 20
 DEFAULT_EXCERPT_MAX_LENGTH = 280
-DEFAULT_INGEST_TIMEOUT_SECONDS = 8.0
+DEFAULT_INGEST_TIMEOUT_SECONDS = DEFAULT_WEB_SOURCE_TIMEOUT_SECONDS
 DEFAULT_MAX_INGEST_CHARACTERS = 200_000
 
 
 class ContentIngestionError(Exception):
     """Raised when content ingestion cannot produce usable analysis text."""
-
-
-@dataclass(frozen=True)
-class UrlFetchPayload:
-    """Raw URL response payload from the fetch layer."""
-
-    body_text: str
-    content_type: str
-
-
-class UrlContentFetcher(Protocol):
-    """Protocol for swappable URL content acquisition implementations."""
-
-    def fetch(self, *, url: str) -> UrlFetchPayload: ...
-
-
-class FetchedContentExtractor(Protocol):
-    """Protocol for swappable fetched-content extraction implementations."""
-
-    def extract(self, *, body_text: str, content_type: str) -> tuple[str, str]: ...
-
-
-class HttpxUrlContentFetcher:
-    """HTTP fetcher implementation for sync MVP ingestion."""
-
-    def __init__(
-        self,
-        *,
-        timeout_seconds: float = DEFAULT_INGEST_TIMEOUT_SECONDS,
-    ) -> None:
-        self._timeout_seconds = timeout_seconds
-
-    def fetch(self, *, url: str) -> UrlFetchPayload:
-        """Fetch URL content and return body text plus response content type."""
-
-        safe_url = validate_external_source_url(url)
-        parsed = urlparse(safe_url)
-        if parsed.scheme not in {"http", "https"}:
-            raise ContentIngestionError("URL ingestion supports only http/https sources.")
-
-        response = httpx.get(
-            safe_url,
-            follow_redirects=True,
-            timeout=self._timeout_seconds,
-            headers={
-                "User-Agent": ("TermsAnalyzerBot/0.1 (+https://example.invalid/content-ingestion)")
-            },
-        )
-        response.raise_for_status()
-        return UrlFetchPayload(
-            body_text=response.text,
-            content_type=response.headers.get("content-type", ""),
-        )
-
-
-class SimpleFetchedContentExtractor:
-    """Lightweight fetched-content extractor for sync MVP ingestion.
-
-    This extraction strategy is intentionally simple. It is designed to be
-    replaced later by richer HTML/article extraction while preserving the same
-    ingestion service interface.
-    """
-
-    def extract(self, *, body_text: str, content_type: str) -> tuple[str, str]:
-        normalized_content_type = content_type.lower()
-        if "html" in normalized_content_type or self._looks_like_html(body_text):
-            return self._extract_text_from_html(body_text), "url_fetch_html_tag_strip"
-        return self._normalize_text(unescape(body_text)), "url_fetch_plain_text"
-
-    def _extract_text_from_html(self, html_text: str) -> str:
-        """Extract plain text from HTML via lightweight regex-based stripping."""
-
-        without_scripts = re.sub(
-            r"(?is)<(script|style|noscript|svg)[^>]*>.*?</\1>",
-            " ",
-            html_text,
-        )
-        without_tags = re.sub(r"(?s)<[^>]+>", " ", without_scripts)
-        return self._normalize_text(unescape(without_tags))
-
-    def _normalize_text(self, value: str) -> str:
-        return normalize_untrusted_text(value)
-
-    def _looks_like_html(self, text: str) -> bool:
-        lowered = text.lower()
-        return "<html" in lowered or "<body" in lowered or "<div" in lowered
 
 
 class ContentIngestionService:

--- a/backend/app/services/request_subject.py
+++ b/backend/app/services/request_subject.py
@@ -1,0 +1,16 @@
+"""Shared owner-subject value object for authenticated service calls.
+
+Services use this small immutable type instead of dealing with transport-layer
+auth details directly. It keeps owner scoping explicit without coupling domain
+logic to FastAPI or JWT parsing concerns.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RequestSubject:
+    """Identity tuple used for owner-scoped data access."""
+
+    subject_type: str
+    subject_id: str

--- a/backend/app/services/submission_preparation.py
+++ b/backend/app/services/submission_preparation.py
@@ -20,11 +20,16 @@ Architectural boundary:
 
 from dataclasses import dataclass
 from datetime import datetime
-import re
 
+from ..core.input_validation import (
+    normalize_untrusted_text,
+    sanitize_optional_single_line_text,
+    sanitize_terms_text,
+)
 from .content_ingestion import (
     ContentIngestionError,
     ContentIngestionService,
+    DEFAULT_MAX_INGEST_CHARACTERS,
     MIN_ANALYZABLE_TEXT_LENGTH,
 )
 from .extraction_contracts import (
@@ -73,10 +78,14 @@ class SubmissionPreparationService:
     def prepare_terms_text_for_storage(self, *, terms_text: str) -> str:
         """Normalize and validate direct agreement text submissions."""
 
-        normalized_terms_text = self.normalize_text(terms_text)
-        if len(normalized_terms_text) < MIN_ANALYZABLE_TEXT_LENGTH:
-            raise InvalidSubmissionError("Agreement text must be at least 20 characters.")
-        return normalized_terms_text
+        try:
+            return sanitize_terms_text(
+                terms_text,
+                min_length=MIN_ANALYZABLE_TEXT_LENGTH,
+                max_length=DEFAULT_MAX_INGEST_CHARACTERS,
+            )
+        except ValueError as error:
+            raise InvalidSubmissionError(str(error)) from error
 
     def prepare_submission(self, *, submission: AnalysisSubmission) -> ExtractionIngestionResult:
         """Prepare legacy one-shot API payloads into extraction boundary DTOs."""
@@ -163,15 +172,16 @@ class SubmissionPreparationService:
     def normalize_text(self, value: str) -> str:
         """Collapse whitespace to keep storage and analysis inputs deterministic."""
 
-        return re.sub(r"\s+", " ", value).strip()
+        return normalize_untrusted_text(value)
 
     def _normalize_optional_value(self, value: str | None) -> str | None:
         """Normalize optional strings and collapse empty values to `None`."""
 
-        if value is None:
-            return None
-        normalized = self.normalize_text(value)
-        return normalized or None
+        return sanitize_optional_single_line_text(
+            value,
+            field_name="Field",
+            max_length=DEFAULT_MAX_INGEST_CHARACTERS,
+        )
 
     def _resolve_ingestion_source(
         self,

--- a/backend/app/services/tracked_policy_service.py
+++ b/backend/app/services/tracked_policy_service.py
@@ -71,9 +71,7 @@ class TrackedPolicyService:
             )
         )
         if existing_tracked_policy is not None:
-            raise DuplicateTrackedPolicyError(
-                "That policy is already in your watchlist."
-            )
+            raise DuplicateTrackedPolicyError("That policy is already in your watchlist.")
 
         try:
             inspected_source = self._public_web_source_inspector.inspect_url(
@@ -115,6 +113,4 @@ class TrackedPolicyService:
             subject_id=subject.subject_id,
         )
         if deactivated_policy is None:
-            raise TrackedPolicyNotFoundError(
-                f"Tracked policy {tracked_policy_id} was not found."
-            )
+            raise TrackedPolicyNotFoundError(f"Tracked policy {tracked_policy_id} was not found.")

--- a/backend/app/services/tracked_policy_service.py
+++ b/backend/app/services/tracked_policy_service.py
@@ -1,0 +1,120 @@
+"""Tracked-policy watchlist orchestration.
+
+This service owns the authenticated watchlist workflow:
+- canonicalize and verify a submitted policy URL
+- prevent duplicate active registrations per owner
+- persist owner-scoped tracked-policy records
+- expose active-list and soft-delete behavior to the API layer
+
+It intentionally stays separate from analysis-report orchestration so policy
+tracking can evolve into its own snapshot/versioning slice without inheriting
+report-specific responsibilities.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from ..repositories.errors import ActiveTrackedPolicyConflictError
+from ..repositories.interfaces import TrackedPolicyRepository
+from ..repositories.models import StoredTrackedPolicy
+from ..repositories.policy_tracking_status import PolicyTrackingStatus
+from .request_subject import RequestSubject
+from .web_source import (
+    PublicWebSourceInspector,
+    WebSourceInspectionError,
+    canonicalize_public_source_url,
+)
+
+
+class DuplicateTrackedPolicyError(Exception):
+    """Raised when the owner already has an active tracked policy for the URL."""
+
+
+class TrackedPolicyNotFoundError(Exception):
+    """Raised when a tracked policy is not found for the active owner subject."""
+
+
+class InvalidTrackedPolicySourceError(Exception):
+    """Raised when a submitted source URL cannot be used for watchlist tracking."""
+
+
+class TrackedPolicyService:
+    """Coordinate tracked-policy registration, listing, and removal."""
+
+    def __init__(
+        self,
+        *,
+        tracked_policy_repository: TrackedPolicyRepository,
+        public_web_source_inspector: PublicWebSourceInspector | None = None,
+    ) -> None:
+        self._tracked_policy_repository = tracked_policy_repository
+        self._public_web_source_inspector = (
+            public_web_source_inspector or PublicWebSourceInspector()
+        )
+
+    def create_tracked_policy(
+        self, *, subject: RequestSubject, source_url: str
+    ) -> StoredTrackedPolicy:
+        """Verify and persist one tracked policy for the active owner subject."""
+
+        try:
+            canonical_url = canonicalize_public_source_url(source_url)
+        except ValueError as error:
+            raise InvalidTrackedPolicySourceError(str(error)) from error
+
+        existing_tracked_policy = (
+            self._tracked_policy_repository.get_active_by_canonical_url_for_subject(
+                canonical_url=canonical_url,
+                subject_type=subject.subject_type,
+                subject_id=subject.subject_id,
+            )
+        )
+        if existing_tracked_policy is not None:
+            raise DuplicateTrackedPolicyError(
+                "That policy is already in your watchlist."
+            )
+
+        try:
+            inspected_source = self._public_web_source_inspector.inspect_url(
+                source_url=canonical_url
+            )
+        except WebSourceInspectionError as error:
+            raise InvalidTrackedPolicySourceError(str(error)) from error
+
+        try:
+            return self._tracked_policy_repository.create(
+                subject_type=subject.subject_type,
+                subject_id=subject.subject_id,
+                canonical_url=inspected_source.canonical_url,
+                display_name=inspected_source.display_name,
+                source_type=inspected_source.source_type,
+                tracking_status=PolicyTrackingStatus.PENDING_FIRST_SNAPSHOT,
+                last_checked_at=inspected_source.last_checked_at,
+                active=True,
+            )
+        except ActiveTrackedPolicyConflictError as error:
+            raise DuplicateTrackedPolicyError(
+                "That policy is already in your watchlist."
+            ) from error
+
+    def list_tracked_policies(self, *, subject: RequestSubject) -> list[StoredTrackedPolicy]:
+        """Return active tracked policies for the request subject, newest first."""
+
+        return self._tracked_policy_repository.list_active_for_subject(
+            subject_type=subject.subject_type,
+            subject_id=subject.subject_id,
+        )
+
+    def remove_tracked_policy(self, *, subject: RequestSubject, tracked_policy_id: UUID) -> None:
+        """Soft-delete one active tracked policy for the request subject."""
+
+        deactivated_policy = self._tracked_policy_repository.deactivate_for_subject(
+            tracked_policy_id=tracked_policy_id,
+            subject_type=subject.subject_type,
+            subject_id=subject.subject_id,
+        )
+        if deactivated_policy is None:
+            raise TrackedPolicyNotFoundError(
+                f"Tracked policy {tracked_policy_id} was not found."
+            )

--- a/backend/app/services/web_source.py
+++ b/backend/app/services/web_source.py
@@ -151,9 +151,9 @@ def canonicalize_public_source_url(value: str) -> str:
     normalized_hostname = (parsed.hostname or "").lower()
     normalized_port = parsed.port
 
-    if (
-        normalized_port is not None
-        and ((normalized_scheme == "http" and normalized_port == 80) or (normalized_scheme == "https" and normalized_port == 443))
+    if normalized_port is not None and (
+        (normalized_scheme == "http" and normalized_port == 80)
+        or (normalized_scheme == "https" and normalized_port == 443)
     ):
         normalized_port = None
 
@@ -164,9 +164,7 @@ def canonicalize_public_source_url(value: str) -> str:
         doseq=True,
     )
 
-    return urlunsplit(
-        (normalized_scheme, normalized_netloc, normalized_path, normalized_query, "")
-    )
+    return urlunsplit((normalized_scheme, normalized_netloc, normalized_path, normalized_query, ""))
 
 
 class PublicWebSourceInspector:
@@ -203,9 +201,7 @@ class PublicWebSourceInspector:
             body_text=payload.body_text,
             content_type=payload.content_type,
         ):
-            raise WebSourceInspectionError(
-                "That URL does not appear to be a readable policy page."
-            )
+            raise WebSourceInspectionError("That URL does not appear to be a readable policy page.")
         if len(extracted_text) < MIN_TRACKABLE_SOURCE_TEXT_LENGTH:
             raise WebSourceInspectionError(
                 "That page did not contain enough readable policy text to track."

--- a/backend/app/services/web_source.py
+++ b/backend/app/services/web_source.py
@@ -1,0 +1,271 @@
+"""Shared public-web-source utilities used by URL-based workflows.
+
+This module owns the neutral URL boundary for:
+- validating and canonicalizing public source URLs
+- performing lightweight fetches against readable web pages
+- extracting simple text/title metadata from fetched responses
+
+It deliberately stays generic so both watchlist registration and future
+URL-driven workflows can reuse the same fetch and inspection seams without
+depending on report-ingestion internals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from html import unescape
+import re
+from typing import Protocol
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import httpx
+
+from ..core.input_validation import normalize_untrusted_text, validate_external_source_url
+
+DEFAULT_WEB_SOURCE_TIMEOUT_SECONDS = 8.0
+MIN_TRACKABLE_SOURCE_TEXT_LENGTH = 20
+
+_TITLE_PATTERN = re.compile(r"(?is)<title[^>]*>(.*?)</title>")
+
+
+class WebSourceInspectionError(Exception):
+    """Raised when a public web source cannot be verified for tracking use."""
+
+
+@dataclass(frozen=True)
+class UrlFetchPayload:
+    """Raw HTTP response payload returned by a URL fetcher."""
+
+    body_text: str
+    content_type: str
+    final_url: str | None = None
+
+
+@dataclass(frozen=True)
+class InspectedWebSource:
+    """Verified public web source information used by registration workflows."""
+
+    canonical_url: str
+    display_name: str
+    source_type: str
+    last_checked_at: datetime
+
+
+class UrlContentFetcher(Protocol):
+    """Protocol for swappable URL content acquisition implementations."""
+
+    def fetch(self, *, url: str) -> UrlFetchPayload: ...
+
+
+class FetchedContentExtractor(Protocol):
+    """Protocol for swappable fetched-content extraction implementations."""
+
+    def extract(self, *, body_text: str, content_type: str) -> tuple[str, str]: ...
+
+    def extract_title(self, *, body_text: str, content_type: str) -> str | None: ...
+
+
+class HttpxUrlContentFetcher:
+    """HTTP fetcher implementation for sync URL inspection and ingestion."""
+
+    def __init__(
+        self,
+        *,
+        timeout_seconds: float = DEFAULT_WEB_SOURCE_TIMEOUT_SECONDS,
+    ) -> None:
+        self._timeout_seconds = timeout_seconds
+
+    def fetch(self, *, url: str) -> UrlFetchPayload:
+        """Fetch URL content and return body text plus response metadata."""
+
+        safe_url = validate_external_source_url(url)
+        response = httpx.get(
+            safe_url,
+            follow_redirects=True,
+            timeout=self._timeout_seconds,
+            headers={
+                "User-Agent": ("TermsAnalyzerBot/0.1 (+https://example.invalid/content-ingestion)")
+            },
+        )
+        response.raise_for_status()
+        return UrlFetchPayload(
+            body_text=response.text,
+            content_type=response.headers.get("content-type", ""),
+            final_url=str(response.url),
+        )
+
+
+class SimpleFetchedContentExtractor:
+    """Lightweight fetched-content extractor for readable web pages."""
+
+    def extract(self, *, body_text: str, content_type: str) -> tuple[str, str]:
+        normalized_content_type = content_type.lower()
+        if "html" in normalized_content_type or self._looks_like_html(body_text):
+            return self._extract_text_from_html(body_text), "url_fetch_html_tag_strip"
+        return self._normalize_text(unescape(body_text)), "url_fetch_plain_text"
+
+    def extract_title(self, *, body_text: str, content_type: str) -> str | None:
+        normalized_content_type = content_type.lower()
+        if "html" not in normalized_content_type and not self._looks_like_html(body_text):
+            return None
+
+        match = _TITLE_PATTERN.search(body_text)
+        if not match:
+            return None
+        title = self._normalize_text(unescape(match.group(1)))
+        return title or None
+
+    def looks_like_html(self, *, body_text: str, content_type: str) -> bool:
+        """Return whether the fetched payload should be treated as HTML-like."""
+
+        normalized_content_type = content_type.lower()
+        return "html" in normalized_content_type or self._looks_like_html(body_text)
+
+    def _extract_text_from_html(self, html_text: str) -> str:
+        """Extract plain text from HTML via lightweight regex-based stripping."""
+
+        without_scripts = re.sub(
+            r"(?is)<(script|style|noscript|svg)[^>]*>.*?</\1>",
+            " ",
+            html_text,
+        )
+        without_tags = re.sub(r"(?s)<[^>]+>", " ", without_scripts)
+        return self._normalize_text(unescape(without_tags))
+
+    def _normalize_text(self, value: str) -> str:
+        return normalize_untrusted_text(value)
+
+    def _looks_like_html(self, text: str) -> bool:
+        lowered = text.lower()
+        return "<html" in lowered or "<body" in lowered or "<div" in lowered
+
+
+def canonicalize_public_source_url(value: str) -> str:
+    """Return a stable canonical representation for a validated public URL."""
+
+    validated_url = validate_external_source_url(value)
+    parsed = urlsplit(validated_url)
+
+    normalized_scheme = parsed.scheme.lower()
+    normalized_hostname = (parsed.hostname or "").lower()
+    normalized_port = parsed.port
+
+    if (
+        normalized_port is not None
+        and ((normalized_scheme == "http" and normalized_port == 80) or (normalized_scheme == "https" and normalized_port == 443))
+    ):
+        normalized_port = None
+
+    normalized_netloc = _build_netloc(hostname=normalized_hostname, port=normalized_port)
+    normalized_path = parsed.path or "/"
+    normalized_query = urlencode(
+        sorted(parse_qsl(parsed.query, keep_blank_values=True)),
+        doseq=True,
+    )
+
+    return urlunsplit(
+        (normalized_scheme, normalized_netloc, normalized_path, normalized_query, "")
+    )
+
+
+class PublicWebSourceInspector:
+    """Verify that a public URL points to a readable page suitable for tracking."""
+
+    def __init__(
+        self,
+        *,
+        url_content_fetcher: UrlContentFetcher | None = None,
+        fetched_content_extractor: FetchedContentExtractor | None = None,
+    ) -> None:
+        self._url_content_fetcher = url_content_fetcher or HttpxUrlContentFetcher()
+        self._fetched_content_extractor = (
+            fetched_content_extractor or SimpleFetchedContentExtractor()
+        )
+
+    def inspect_url(self, *, source_url: str) -> InspectedWebSource:
+        """Canonicalize, fetch, and verify a source URL for watchlist registration."""
+
+        canonical_url = canonicalize_public_source_url(source_url)
+        try:
+            payload = self._url_content_fetcher.fetch(url=canonical_url)
+        except (httpx.HTTPError, ValueError) as error:
+            raise WebSourceInspectionError(
+                "We couldn't reach that policy page. Check the URL and try again."
+            ) from error
+
+        extracted_text, _ = self._fetched_content_extractor.extract(
+            body_text=payload.body_text,
+            content_type=payload.content_type,
+        )
+        if not self._is_readable_source(
+            extracted_text=extracted_text,
+            body_text=payload.body_text,
+            content_type=payload.content_type,
+        ):
+            raise WebSourceInspectionError(
+                "That URL does not appear to be a readable policy page."
+            )
+        if len(extracted_text) < MIN_TRACKABLE_SOURCE_TEXT_LENGTH:
+            raise WebSourceInspectionError(
+                "That page did not contain enough readable policy text to track."
+            )
+
+        display_name = self._derive_display_name(
+            canonical_url=canonical_url,
+            body_text=payload.body_text,
+            content_type=payload.content_type,
+        )
+        return InspectedWebSource(
+            canonical_url=canonical_url,
+            display_name=display_name,
+            source_type="url",
+            last_checked_at=datetime.now(timezone.utc),
+        )
+
+    def _derive_display_name(
+        self,
+        *,
+        canonical_url: str,
+        body_text: str,
+        content_type: str,
+    ) -> str:
+        title = self._fetched_content_extractor.extract_title(
+            body_text=body_text,
+            content_type=content_type,
+        )
+        if title:
+            return title
+
+        parsed = urlsplit(canonical_url)
+        return (parsed.hostname or canonical_url).lower()
+
+    def _is_readable_source(
+        self,
+        *,
+        extracted_text: str,
+        body_text: str,
+        content_type: str,
+    ) -> bool:
+        lowered_content_type = content_type.lower()
+        if not lowered_content_type:
+            return bool(extracted_text)
+        if lowered_content_type.startswith("text/"):
+            return True
+        if "html" in lowered_content_type or "xhtml" in lowered_content_type:
+            return True
+        extractor = self._fetched_content_extractor
+        looks_like_html = getattr(extractor, "looks_like_html", None)
+        if callable(looks_like_html):
+            return bool(looks_like_html(body_text=body_text, content_type=content_type))
+        return bool(extracted_text)
+
+
+def _build_netloc(*, hostname: str, port: int | None) -> str:
+    if ":" in hostname and not hostname.startswith("["):
+        normalized_hostname = f"[{hostname}]"
+    else:
+        normalized_hostname = hostname
+    if port is None:
+        return normalized_hostname
+    return f"{normalized_hostname}:{port}"

--- a/backend/tests/test_agreements_api.py
+++ b/backend/tests/test_agreements_api.py
@@ -8,6 +8,15 @@ from app.api.deps import reset_demo_storage
 from app.auth.subject_resolver import AuthSubjectResolver
 from app.auth.supabase_jwt import SupabaseJwtVerifier
 from app.main import create_app
+from app.repositories.in_memory import (
+    InMemoryAgreementRepository,
+    InMemoryReportRepository,
+    InMemoryStorage,
+)
+from app.services.ai_provider import AnalysisProviderRuntimeConfig, build_analysis_provider
+from app.services.analysis_execution import SyncAnalysisExecutionStrategy
+from app.services.analysis_service import AnalysisOrchestrationService
+from app.services.submission_preparation import SubmissionPreparationService
 
 TEST_SECRET = "f" * 48
 TEST_ISSUER = "https://agreements-test.supabase.co/auth/v1"
@@ -51,6 +60,36 @@ def client() -> TestClient:
     return TestClient(create_app())
 
 
+def _build_analysis_service_with_provider_budget(
+    *,
+    max_input_tokens: int,
+    estimated_chars_per_token: int,
+) -> AnalysisOrchestrationService:
+    storage = InMemoryStorage()
+    agreement_repository = InMemoryAgreementRepository(storage)
+    report_repository = InMemoryReportRepository(storage)
+
+    return AnalysisOrchestrationService(
+        agreement_repository=agreement_repository,
+        report_repository=report_repository,
+        analysis_execution_strategy=SyncAnalysisExecutionStrategy(
+            analysis_provider=build_analysis_provider(
+                config=AnalysisProviderRuntimeConfig(
+                    mode="ai",
+                    ai_provider_kind="gemini",
+                    gemini_api_key="test-key",
+                    gemini_model_name="gemini-2.5-flash",
+                    ai_fallback_to_deterministic=False,
+                    gemini_max_input_tokens=max_input_tokens,
+                    gemini_estimated_chars_per_token=estimated_chars_per_token,
+                )
+            ),
+            report_repository=report_repository,
+        ),
+        submission_preparation_service=SubmissionPreparationService(),
+    )
+
+
 def test_create_agreement_then_trigger_manual_analysis(client: TestClient) -> None:
     create_payload = {
         "title": "Demo Terms",
@@ -91,6 +130,45 @@ def test_create_agreement_rejects_short_terms_text(client: TestClient) -> None:
     assert response.status_code == 422
 
 
+def test_create_agreement_rejects_private_source_url(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/agreements",
+        json={
+            "source_url": "http://localhost/private-terms",
+            "terms_text": "These terms include arbitration and automatic renewal language.",
+        },
+        headers=_auth_headers("user-a"),
+    )
+    assert response.status_code == 422
+
+
+def test_create_agreement_sanitizes_title_and_terms_text(client: TestClient) -> None:
+    create_response = client.post(
+        "/api/v1/agreements",
+        json={
+            "title": "<script>alert(1)</script> Demo Terms",
+            "terms_text": (
+                "<div>These terms include arbitration and a class action waiver. "
+                "The subscription renews automatically unless canceled.</div>"
+            ),
+        },
+        headers=_auth_headers("user-a"),
+    )
+    assert create_response.status_code == 201
+    agreement = create_response.json()
+    assert agreement["title"] == "Demo Terms"
+
+    analyze_response = client.post(
+        f"/api/v1/agreements/{agreement['id']}/analyses",
+        json={"trigger": "manual"},
+        headers=_auth_headers("user-a"),
+    )
+    assert analyze_response.status_code == 201
+    report = analyze_response.json()
+    assert "<script>" not in report["raw_input_excerpt"].lower()
+    assert "alert(1)" not in report["raw_input_excerpt"].lower()
+
+
 def test_trigger_manual_analysis_rejects_invalid_trigger(client: TestClient) -> None:
     create_response = client.post(
         "/api/v1/agreements",
@@ -106,3 +184,39 @@ def test_trigger_manual_analysis_rejects_invalid_trigger(client: TestClient) -> 
     )
     assert response.status_code == 400
     assert "manual" in response.json()["detail"]
+
+
+def test_trigger_manual_analysis_rejects_terms_that_exceed_gemini_prompt_budget(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    reset_demo_storage()
+    monkeypatch.setattr(
+        deps,
+        "_analysis_service",
+        _build_analysis_service_with_provider_budget(
+            max_input_tokens=120,
+            estimated_chars_per_token=1,
+        ),
+    )
+
+    create_response = client.post(
+        "/api/v1/agreements",
+        json={
+            "terms_text": (
+                "These terms include arbitration, automatic renewal, broad data sharing, "
+                "and unilateral change rights. " * 5
+            )
+        },
+        headers=_auth_headers("user-a"),
+    )
+    assert create_response.status_code == 201
+    agreement_id = create_response.json()["id"]
+
+    analyze_response = client.post(
+        f"/api/v1/agreements/{agreement_id}/analyses",
+        json={"trigger": "manual"},
+        headers=_auth_headers("user-a"),
+    )
+
+    assert analyze_response.status_code == 422
+    assert "too large for gemini analysis" in analyze_response.json()["detail"].lower()

--- a/backend/tests/test_ai_provider_contract.py
+++ b/backend/tests/test_ai_provider_contract.py
@@ -4,6 +4,7 @@ import pytest
 from app.services.ai_provider import (
     AnalysisInput,
     AnalysisInputMetadata,
+    AnalysisProviderInputError,
     AnalysisProviderInvocationError,
     AnalysisProviderRuntimeConfig,
     DeterministicAnalysisProvider,
@@ -154,6 +155,27 @@ def test_fallback_provider_uses_deterministic_when_primary_fails() -> None:
     assert any("fallback" in warning.lower() for warning in result.execution_metadata.warnings)
 
 
+def test_fallback_provider_does_not_mask_provider_input_errors() -> None:
+    class _TooLargeProvider:
+        def analyze(self, *, analysis_input: AnalysisInput):
+            _ = analysis_input
+            raise AnalysisProviderInputError("submission too large")
+
+    provider = FallbackAnalysisProvider(
+        primary=_TooLargeProvider(),
+        fallback=DeterministicAnalysisProvider(),
+    )
+
+    with pytest.raises(AnalysisProviderInputError):
+        provider.analyze(
+            analysis_input=AnalysisInput(
+                source_type="text",
+                source_value="manual_text_submission",
+                normalized_text="These terms include automatic renewal and arbitration.",
+            )
+        )
+
+
 def test_provider_builder_fallback_handles_runtime_ai_invocation_failure(
     monkeypatch,
 ) -> None:
@@ -207,5 +229,33 @@ def test_provider_builder_without_fallback_raises_on_runtime_ai_failure(
                 source_type="text",
                 source_value="manual_text_submission",
                 normalized_text="These terms include automatic renewal and arbitration.",
+            )
+        )
+
+
+def test_gemini_provider_rejects_oversized_prompt_before_http_call(
+    monkeypatch,
+) -> None:
+    def _unexpected_http_post(*_args, **_kwargs):
+        raise AssertionError("Gemini HTTP invocation should not run for oversized prompts.")
+
+    monkeypatch.setattr("app.services.ai_provider.httpx.post", _unexpected_http_post)
+
+    provider = GeminiAnalysisProvider(
+        api_key="test-key",
+        model_name="gemini-2.5-flash",
+        base_url="https://generativelanguage.googleapis.com/v1beta",
+        timeout_seconds=20,
+        temperature=0.1,
+        max_input_tokens=120,
+        estimated_chars_per_token=1,
+    )
+
+    with pytest.raises(AnalysisProviderInputError):
+        provider.analyze(
+            analysis_input=AnalysisInput(
+                source_type="text",
+                source_value="manual_text_submission",
+                normalized_text=("These terms include arbitration and automatic renewal. " * 6),
             )
         )

--- a/backend/tests/test_in_memory_repository.py
+++ b/backend/tests/test_in_memory_repository.py
@@ -6,9 +6,11 @@ import pytest
 from app.repositories.in_memory import (
     InMemoryAgreementRepository,
     InMemoryReportRepository,
+    InMemoryTrackedPolicyRepository,
     InMemoryStorage,
 )
 from app.repositories.analysis_status import AnalysisLifecycleStatus
+from app.repositories.policy_tracking_status import PolicyTrackingStatus
 from app.repositories.models import StoredFlaggedClause
 
 
@@ -208,3 +210,83 @@ def test_report_repository_rejects_unknown_lifecycle_status() -> None:
             flagged_clauses=[],
             completed_at=datetime.now(timezone.utc),
         )
+
+
+def test_tracked_policy_repository_scopes_active_policies_by_owner_and_hides_inactive() -> None:
+    storage = InMemoryStorage()
+    repository = InMemoryTrackedPolicyRepository(storage)
+
+    owner_a_policy = repository.create(
+        subject_type="supabase_user",
+        subject_id="user-a",
+        canonical_url="https://service-a.example/terms",
+        display_name="Service A Terms",
+        source_type="url",
+        tracking_status=PolicyTrackingStatus.PENDING_FIRST_SNAPSHOT,
+        last_checked_at=datetime.now(timezone.utc),
+    )
+    repository.create(
+        subject_type="supabase_user",
+        subject_id="user-b",
+        canonical_url="https://service-b.example/terms",
+        display_name="Service B Terms",
+        source_type="url",
+        tracking_status=PolicyTrackingStatus.ACTIVE,
+        last_checked_at=datetime.now(timezone.utc),
+    )
+
+    deactivated_policy = repository.deactivate_for_subject(
+        tracked_policy_id=owner_a_policy.id,
+        subject_type="supabase_user",
+        subject_id="user-a",
+    )
+
+    assert deactivated_policy is not None
+    assert deactivated_policy.active is False
+    assert repository.list_active_for_subject(
+        subject_type="supabase_user",
+        subject_id="user-a",
+    ) == []
+    assert len(
+        repository.list_active_for_subject(
+            subject_type="supabase_user",
+            subject_id="user-b",
+        )
+    ) == 1
+
+
+def test_tracked_policy_repository_lists_newest_active_first() -> None:
+    storage = InMemoryStorage()
+    repository = InMemoryTrackedPolicyRepository(storage)
+
+    older_policy = repository.create(
+        subject_type="supabase_user",
+        subject_id="user-a",
+        canonical_url="https://service-a.example/terms",
+        display_name="Service A Terms",
+        source_type="url",
+        tracking_status=PolicyTrackingStatus.PENDING_FIRST_SNAPSHOT,
+        last_checked_at=datetime.now(timezone.utc),
+    )
+
+    time.sleep(0.001)
+
+    newer_policy = repository.create(
+        subject_type="supabase_user",
+        subject_id="user-a",
+        canonical_url="https://service-b.example/terms",
+        display_name="Service B Terms",
+        source_type="url",
+        tracking_status=PolicyTrackingStatus.ACTIVE,
+        last_checked_at=datetime.now(timezone.utc),
+    )
+
+    tracked_policies = repository.list_active_for_subject(
+        subject_type="supabase_user",
+        subject_id="user-a",
+    )
+
+    assert [tracked_policy.id for tracked_policy in tracked_policies] == [
+        newer_policy.id,
+        older_policy.id,
+    ]

--- a/backend/tests/test_in_memory_repository.py
+++ b/backend/tests/test_in_memory_repository.py
@@ -243,16 +243,22 @@ def test_tracked_policy_repository_scopes_active_policies_by_owner_and_hides_ina
 
     assert deactivated_policy is not None
     assert deactivated_policy.active is False
-    assert repository.list_active_for_subject(
-        subject_type="supabase_user",
-        subject_id="user-a",
-    ) == []
-    assert len(
+    assert (
         repository.list_active_for_subject(
             subject_type="supabase_user",
-            subject_id="user-b",
+            subject_id="user-a",
         )
-    ) == 1
+        == []
+    )
+    assert (
+        len(
+            repository.list_active_for_subject(
+                subject_type="supabase_user",
+                subject_id="user-b",
+            )
+        )
+        == 1
+    )
 
 
 def test_tracked_policy_repository_lists_newest_active_first() -> None:

--- a/backend/tests/test_rate_limiting.py
+++ b/backend/tests/test_rate_limiting.py
@@ -1,0 +1,175 @@
+from datetime import datetime, timedelta, timezone
+import re
+
+from fastapi.testclient import TestClient
+import jwt
+import pytest
+
+from app.api import deps
+from app.api.deps import reset_demo_storage
+from app.auth.subject_resolver import AuthSubjectResolver
+from app.auth.supabase_jwt import SupabaseJwtVerifier
+from app.main import create_app
+from app.security.rate_limit import RateLimitPolicy, RequestRateLimiter
+
+TEST_SECRET = "g" * 48
+TEST_ISSUER = "https://rate-limit-test.supabase.co/auth/v1"
+TEST_AUDIENCE = "authenticated"
+TEST_IP = "198.51.100.24"
+
+
+def _issue_token(*, sub: str, exp_offset_seconds: int = 3600) -> str:
+    payload = {
+        "sub": sub,
+        "aud": TEST_AUDIENCE,
+        "iss": TEST_ISSUER,
+        "exp": int(
+            (datetime.now(timezone.utc) + timedelta(seconds=exp_offset_seconds)).timestamp()
+        ),
+    }
+    return jwt.encode(payload, TEST_SECRET, algorithm="HS256")
+
+
+def _auth_headers(user_id: str, *, ip: str = TEST_IP) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {_issue_token(sub=user_id)}",
+        "X-Forwarded-For": ip,
+    }
+
+
+def _build_rate_limiter(*policies: RateLimitPolicy) -> RequestRateLimiter:
+    return RequestRateLimiter(
+        policies=policies,
+        subject_resolver_provider=lambda: deps._request_subject_resolver,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    reset_demo_storage()
+    verifier = SupabaseJwtVerifier(
+        jwt_secret=TEST_SECRET,
+        expected_issuer=TEST_ISSUER,
+        expected_audience=TEST_AUDIENCE,
+        require_signature_verification=True,
+    )
+    monkeypatch.setattr(
+        deps,
+        "_request_subject_resolver",
+        AuthSubjectResolver(jwt_verifier=verifier),
+    )
+
+
+def test_general_api_rate_limit_blocks_repeated_report_listing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        deps,
+        "_request_rate_limiter",
+        _build_rate_limiter(
+            RateLimitPolicy(
+                name="api_requests",
+                request_limit=1,
+                window_seconds=60,
+                methods=frozenset({"GET"}),
+                path_pattern=re.compile(r"^/api/v1/reports$"),
+                key_strategy="ip",
+            )
+        ),
+    )
+    client = TestClient(create_app())
+
+    first_response = client.get("/api/v1/reports", headers=_auth_headers("user-a"))
+    second_response = client.get("/api/v1/reports", headers=_auth_headers("user-a"))
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 429
+    assert second_response.json()["policy"] == "api_requests"
+    assert second_response.headers["X-RateLimit-Policy"] == "api_requests"
+    assert int(second_response.headers["Retry-After"]) >= 1
+
+
+def test_agreement_creation_rate_limit_blocks_repeated_submissions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        deps,
+        "_request_rate_limiter",
+        _build_rate_limiter(
+            RateLimitPolicy(
+                name="agreement_creation",
+                request_limit=1,
+                window_seconds=600,
+                methods=frozenset({"POST"}),
+                path_pattern=re.compile(r"^/api/v1/agreements$"),
+                key_strategy="subject_or_ip",
+            )
+        ),
+    )
+    client = TestClient(create_app())
+    payload = {
+        "terms_text": (
+            "These terms include arbitration, auto-renewal, and broad unilateral "
+            "change rights that should be analyzed carefully."
+        )
+    }
+
+    first_response = client.post(
+        "/api/v1/agreements", json=payload, headers=_auth_headers("user-a")
+    )
+    second_response = client.post(
+        "/api/v1/agreements",
+        json=payload,
+        headers=_auth_headers("user-a"),
+    )
+
+    assert first_response.status_code == 201
+    assert second_response.status_code == 429
+    assert second_response.json()["policy"] == "agreement_creation"
+
+
+def test_analysis_generation_limit_is_scoped_by_authenticated_subject(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        deps,
+        "_request_rate_limiter",
+        _build_rate_limiter(
+            RateLimitPolicy(
+                name="analysis_generation_burst",
+                request_limit=1,
+                window_seconds=300,
+                methods=frozenset({"POST"}),
+                path_pattern=re.compile(r"^/api/v1/reports/analyze$"),
+                key_strategy="subject_or_ip",
+            )
+        ),
+    )
+    client = TestClient(create_app())
+    payload = {
+        "terms_text": (
+            "These terms include mandatory arbitration, auto-renewal, and a broad "
+            "right to change terms without notice."
+        )
+    }
+
+    first_user_first_response = client.post(
+        "/api/v1/reports/analyze",
+        json=payload,
+        headers=_auth_headers("user-a"),
+    )
+    first_user_second_response = client.post(
+        "/api/v1/reports/analyze",
+        json=payload,
+        headers=_auth_headers("user-a"),
+    )
+    second_user_response = client.post(
+        "/api/v1/reports/analyze",
+        json=payload,
+        headers=_auth_headers("user-b"),
+    )
+
+    assert first_user_first_response.status_code == 201
+    assert first_user_second_response.status_code == 429
+    assert first_user_second_response.json()["policy"] == "analysis_generation_burst"
+    assert second_user_response.status_code == 201

--- a/backend/tests/test_reports_api.py
+++ b/backend/tests/test_reports_api.py
@@ -13,7 +13,12 @@ from app.repositories.in_memory import (
     InMemoryReportRepository,
     InMemoryStorage,
 )
-from app.services.ai_provider import DeterministicAnalysisProvider
+from app.services.ai_provider import (
+    AnalysisProvider,
+    AnalysisProviderRuntimeConfig,
+    DeterministicAnalysisProvider,
+    build_analysis_provider,
+)
 from app.services.analysis_execution import SyncAnalysisExecutionStrategy
 from app.services.analysis_service import AnalysisOrchestrationService
 from app.services.content_ingestion import ContentIngestionService, UrlFetchPayload
@@ -73,6 +78,7 @@ class _StaticUrlFetcher:
 def _build_analysis_service_for_test(
     *,
     content_ingestion_service: ContentIngestionService | None = None,
+    analysis_provider: AnalysisProvider | None = None,
 ) -> AnalysisOrchestrationService:
     storage = InMemoryStorage()
     agreement_repository = InMemoryAgreementRepository(storage)
@@ -82,7 +88,7 @@ def _build_analysis_service_for_test(
         agreement_repository=agreement_repository,
         report_repository=report_repository,
         analysis_execution_strategy=SyncAnalysisExecutionStrategy(
-            analysis_provider=DeterministicAnalysisProvider(),
+            analysis_provider=analysis_provider or DeterministicAnalysisProvider(),
             report_repository=report_repository,
         ),
         submission_preparation_service=SubmissionPreparationService(
@@ -212,6 +218,28 @@ def test_submit_analyze_rejects_missing_input(client: TestClient) -> None:
     assert response.status_code == 422
 
 
+def test_submit_analyze_rejects_extra_fields_and_non_string_types(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/reports/analyze",
+        json={
+            "title": 123,
+            "terms_text": "These terms include arbitration and automatic renewal clauses.",
+            "unexpected": "field",
+        },
+        headers=_auth_headers("user-a"),
+    )
+    assert response.status_code == 422
+
+
+def test_submit_analyze_rejects_private_source_urls(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/reports/analyze",
+        json={"source_url": "http://127.0.0.1/internal-terms"},
+        headers=_auth_headers("user-a"),
+    )
+    assert response.status_code == 422
+
+
 def test_get_report_returns_404_when_report_not_found(client: TestClient) -> None:
     response = client.get(
         "/api/v1/reports/11111111-1111-1111-1111-111111111111",
@@ -288,3 +316,57 @@ def test_submit_analyze_url_only_uses_ingestion_fetch_path_when_available(
     _assert_report_response_contract(report)
     assert report["source_type"] == "url"
     assert "could not be fetched" not in report["raw_input_excerpt"].lower()
+
+
+def test_submit_analyze_sanitizes_html_like_text_input(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/reports/analyze",
+        json={
+            "title": "<script>alert(1)</script> Demo Terms",
+            "terms_text": (
+                "<script>alert(1)</script><section>These terms include arbitration, "
+                "automatic renewal, and unilateral change rights.</section>"
+            ),
+        },
+        headers=_auth_headers("user-a"),
+    )
+
+    assert response.status_code == 201
+    report = response.json()
+    assert report["source_value"] == "Demo Terms"
+    assert "<script>" not in report["raw_input_excerpt"].lower()
+    assert "alert(1)" not in report["raw_input_excerpt"].lower()
+
+
+def test_submit_analyze_rejects_terms_that_exceed_gemini_prompt_budget(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    reset_demo_storage()
+    test_service = _build_analysis_service_for_test(
+        analysis_provider=build_analysis_provider(
+            config=AnalysisProviderRuntimeConfig(
+                mode="ai",
+                ai_provider_kind="gemini",
+                gemini_api_key="test-key",
+                gemini_model_name="gemini-2.5-flash",
+                ai_fallback_to_deterministic=False,
+                gemini_max_input_tokens=120,
+                gemini_estimated_chars_per_token=1,
+            )
+        )
+    )
+    monkeypatch.setattr(deps, "_analysis_service", test_service)
+
+    response = client.post(
+        "/api/v1/reports/analyze",
+        json={
+            "terms_text": (
+                "These terms include arbitration, automatic renewal, broad data sharing, "
+                "and unilateral change rights. " * 5
+            )
+        },
+        headers=_auth_headers("user-a"),
+    )
+
+    assert response.status_code == 422
+    assert "too large for gemini analysis" in response.json()["detail"].lower()

--- a/backend/tests/test_tracked_policies_api.py
+++ b/backend/tests/test_tracked_policies_api.py
@@ -1,0 +1,233 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+import jwt
+import pytest
+
+from app.api import deps
+from app.auth.subject_resolver import AuthSubjectResolver
+from app.auth.supabase_jwt import SupabaseJwtVerifier
+from app.main import create_app
+from app.repositories.in_memory import InMemoryStorage, InMemoryTrackedPolicyRepository
+from app.services.tracked_policy_service import TrackedPolicyService
+from app.services.web_source import PublicWebSourceInspector, UrlFetchPayload
+
+TEST_SECRET = "b" * 48
+TEST_ISSUER = "https://tracked-policy-test.supabase.co/auth/v1"
+TEST_AUDIENCE = "authenticated"
+
+
+class _StaticUrlFetcher:
+    def __init__(self, payload: UrlFetchPayload) -> None:
+        self._payload = payload
+
+    def fetch(self, *, url: str) -> UrlFetchPayload:
+        _ = url
+        return self._payload
+
+
+class _FailingUrlFetcher:
+    def fetch(self, *, url: str) -> UrlFetchPayload:
+        raise ValueError(f"failed to fetch {url}")
+
+
+def _issue_token(*, sub: str, exp_offset_seconds: int = 3600) -> str:
+    payload = {
+        "sub": sub,
+        "aud": TEST_AUDIENCE,
+        "iss": TEST_ISSUER,
+        "exp": int(
+            (datetime.now(timezone.utc) + timedelta(seconds=exp_offset_seconds)).timestamp()
+        ),
+    }
+    return jwt.encode(payload, TEST_SECRET, algorithm="HS256")
+
+
+def _auth_headers(user_id: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {_issue_token(sub=user_id)}"}
+
+
+def _build_tracked_policy_service(*, url_fetcher) -> TrackedPolicyService:
+    storage = InMemoryStorage()
+    repository = InMemoryTrackedPolicyRepository(storage)
+    return TrackedPolicyService(
+        tracked_policy_repository=repository,
+        public_web_source_inspector=PublicWebSourceInspector(url_content_fetcher=url_fetcher),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _jwt_subject_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    verifier = SupabaseJwtVerifier(
+        jwt_secret=TEST_SECRET,
+        expected_issuer=TEST_ISSUER,
+        expected_audience=TEST_AUDIENCE,
+        require_signature_verification=True,
+    )
+    resolver = AuthSubjectResolver(jwt_verifier=verifier)
+    monkeypatch.setattr(deps, "_request_subject_resolver", resolver)
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(create_app())
+
+
+def test_tracked_policies_endpoint_requires_bearer_token(client: TestClient) -> None:
+    response = client.get("/api/v1/tracked-policies")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Missing Bearer token."
+
+
+def test_authenticated_user_can_create_list_and_delete_tracked_policies(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        deps,
+        "_tracked_policy_service",
+        _build_tracked_policy_service(
+            url_fetcher=_StaticUrlFetcher(
+                UrlFetchPayload(
+                    body_text=(
+                        "<html><head><title>Example Terms</title></head>"
+                        "<body>These terms include arbitration and automatic renewal clauses."
+                        "</body></html>"
+                    ),
+                    content_type="text/html",
+                )
+            )
+        ),
+    )
+    owner_headers = _auth_headers("auth-user-a")
+
+    create_response = client.post(
+        "/api/v1/tracked-policies",
+        json={"source_url": "https://Example.com:443/terms?b=2&a=1#frag"},
+        headers=owner_headers,
+    )
+    assert create_response.status_code == 201
+    created_tracked_policy = create_response.json()
+    assert created_tracked_policy["canonical_url"] == "https://example.com/terms?a=1&b=2"
+    assert created_tracked_policy["display_name"] == "Example Terms"
+    assert created_tracked_policy["tracking_status"] == "pending_first_snapshot"
+    assert created_tracked_policy["last_checked_at"] is not None
+
+    list_response = client.get("/api/v1/tracked-policies", headers=owner_headers)
+    assert list_response.status_code == 200
+    assert list_response.json() == [created_tracked_policy]
+
+    delete_response = client.delete(
+        f"/api/v1/tracked-policies/{created_tracked_policy['id']}",
+        headers=owner_headers,
+    )
+    assert delete_response.status_code == 204
+
+    list_after_delete = client.get("/api/v1/tracked-policies", headers=owner_headers)
+    assert list_after_delete.status_code == 200
+    assert list_after_delete.json() == []
+
+
+def test_tracked_policies_are_filtered_by_authenticated_owner(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        deps,
+        "_tracked_policy_service",
+        _build_tracked_policy_service(
+            url_fetcher=_StaticUrlFetcher(
+                UrlFetchPayload(
+                    body_text=(
+                        "<html><body>These terms cover liability, privacy, and cancellation."
+                        "</body></html>"
+                    ),
+                    content_type="text/html",
+                )
+            )
+        ),
+    )
+
+    create_response = client.post(
+        "/api/v1/tracked-policies",
+        json={"source_url": "https://owner-a.example/terms"},
+        headers=_auth_headers("auth-user-a"),
+    )
+    assert create_response.status_code == 201
+    tracked_policy_id = create_response.json()["id"]
+
+    list_owner_a = client.get("/api/v1/tracked-policies", headers=_auth_headers("auth-user-a"))
+    list_owner_b = client.get("/api/v1/tracked-policies", headers=_auth_headers("auth-user-b"))
+    delete_owner_b = client.delete(
+        f"/api/v1/tracked-policies/{tracked_policy_id}",
+        headers=_auth_headers("auth-user-b"),
+    )
+
+    assert len(list_owner_a.json()) == 1
+    assert list_owner_b.json() == []
+    assert delete_owner_b.status_code == 404
+
+
+def test_tracked_policy_create_returns_conflict_for_active_duplicate(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        deps,
+        "_tracked_policy_service",
+        _build_tracked_policy_service(
+            url_fetcher=_StaticUrlFetcher(
+                UrlFetchPayload(
+                    body_text=(
+                        "<html><body>These terms cover liability, privacy, and cancellation."
+                        "</body></html>"
+                    ),
+                    content_type="text/html",
+                )
+            )
+        ),
+    )
+    owner_headers = _auth_headers("auth-user-a")
+
+    first_response = client.post(
+        "/api/v1/tracked-policies",
+        json={"source_url": "https://example.com/terms?b=2&a=1"},
+        headers=owner_headers,
+    )
+    second_response = client.post(
+        "/api/v1/tracked-policies",
+        json={"source_url": "https://Example.com:443/terms?a=1&b=2#fragment"},
+        headers=owner_headers,
+    )
+
+    assert first_response.status_code == 201
+    assert second_response.status_code == 409
+    assert "already in your watchlist" in second_response.json()["detail"].lower()
+
+
+def test_tracked_policy_create_rejects_unreachable_source_url(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        deps,
+        "_tracked_policy_service",
+        _build_tracked_policy_service(url_fetcher=_FailingUrlFetcher()),
+    )
+
+    response = client.post(
+        "/api/v1/tracked-policies",
+        json={"source_url": "https://example.com/terms"},
+        headers=_auth_headers("auth-user-a"),
+    )
+
+    assert response.status_code == 422
+    assert "couldn't reach" in response.json()["detail"].lower()
+
+
+def test_tracked_policy_create_rejects_private_source_url(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/tracked-policies",
+        json={"source_url": "http://localhost/private-terms"},
+        headers=_auth_headers("auth-user-a"),
+    )
+
+    assert response.status_code == 422
+    assert "public hostname" in str(response.json()).lower()

--- a/backend/tests/test_tracked_policy_service.py
+++ b/backend/tests/test_tracked_policy_service.py
@@ -1,0 +1,142 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.repositories.in_memory import InMemoryStorage, InMemoryTrackedPolicyRepository
+from app.repositories.policy_tracking_status import PolicyTrackingStatus
+from app.services.request_subject import RequestSubject
+from app.services.tracked_policy_service import (
+    DuplicateTrackedPolicyError,
+    InvalidTrackedPolicySourceError,
+    TrackedPolicyService,
+)
+from app.services.web_source import (
+    InspectedWebSource,
+    PublicWebSourceInspector,
+    UrlFetchPayload,
+    WebSourceInspectionError,
+    canonicalize_public_source_url,
+)
+
+
+class _StaticUrlFetcher:
+    def __init__(self, payload: UrlFetchPayload) -> None:
+        self._payload = payload
+
+    def fetch(self, *, url: str) -> UrlFetchPayload:
+        _ = url
+        return self._payload
+
+
+class _FailingUrlFetcher:
+    def fetch(self, *, url: str) -> UrlFetchPayload:
+        raise ValueError(f"failed to fetch {url}")
+
+
+class _StubInspector:
+    def __init__(self, inspected_source: InspectedWebSource) -> None:
+        self._inspected_source = inspected_source
+        self.calls = 0
+
+    def inspect_url(self, *, source_url: str) -> InspectedWebSource:
+        _ = source_url
+        self.calls += 1
+        return self._inspected_source
+
+
+def _build_service(*, inspector: PublicWebSourceInspector | _StubInspector) -> TrackedPolicyService:
+    storage = InMemoryStorage()
+    repository = InMemoryTrackedPolicyRepository(storage)
+    return TrackedPolicyService(
+        tracked_policy_repository=repository,
+        public_web_source_inspector=inspector,
+    )
+
+
+def test_canonicalize_public_source_url_normalizes_host_default_port_and_query_order() -> None:
+    canonical_url = canonicalize_public_source_url(
+        "HTTPS://Example.com:443/terms?b=2&a=1&a=0#section"
+    )
+
+    assert canonical_url == "https://example.com/terms?a=0&a=1&b=2"
+
+
+def test_public_web_source_inspector_uses_page_title_for_display_name() -> None:
+    inspector = PublicWebSourceInspector(
+        url_content_fetcher=_StaticUrlFetcher(
+            UrlFetchPayload(
+                body_text=(
+                    "<html><head><title>Example Terms of Service</title></head>"
+                    "<body><main>These terms describe arbitration and automatic renewal clauses."
+                    "</main></body></html>"
+                ),
+                content_type="text/html; charset=utf-8",
+            )
+        )
+    )
+
+    inspected_source = inspector.inspect_url(source_url="https://example.com/legal")
+
+    assert inspected_source.display_name == "Example Terms of Service"
+    assert inspected_source.source_type == "url"
+
+
+def test_public_web_source_inspector_falls_back_to_hostname_when_title_missing() -> None:
+    inspector = PublicWebSourceInspector(
+        url_content_fetcher=_StaticUrlFetcher(
+            UrlFetchPayload(
+                body_text=(
+                    "<html><body>These terms describe cancellation, data sharing, "
+                    "and liability limits in readable text.</body></html>"
+                ),
+                content_type="text/html",
+            )
+        )
+    )
+
+    inspected_source = inspector.inspect_url(source_url="https://Example.com/legal")
+
+    assert inspected_source.display_name == "example.com"
+
+
+def test_tracked_policy_service_rejects_unreachable_source_with_plain_language_error() -> None:
+    service = _build_service(
+        inspector=PublicWebSourceInspector(url_content_fetcher=_FailingUrlFetcher())
+    )
+
+    with pytest.raises(InvalidTrackedPolicySourceError) as error_info:
+        service.create_tracked_policy(
+            subject=RequestSubject(subject_type="supabase_user", subject_id="user-a"),
+            source_url="https://example.com/terms",
+        )
+
+    assert "couldn't reach" in str(error_info.value).lower()
+
+
+def test_tracked_policy_service_rejects_duplicate_active_canonical_url_per_owner() -> None:
+    checked_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+    service = _build_service(
+        inspector=_StubInspector(
+            InspectedWebSource(
+                canonical_url="https://example.com/terms?a=1&b=2",
+                display_name="Example Terms",
+                source_type="url",
+                last_checked_at=checked_at,
+            )
+        )
+    )
+    subject = RequestSubject(subject_type="supabase_user", subject_id="user-a")
+
+    created_tracked_policy = service.create_tracked_policy(
+        subject=subject,
+        source_url="https://example.com/terms?b=2&a=1",
+    )
+
+    assert created_tracked_policy.tracking_status == PolicyTrackingStatus.PENDING_FIRST_SNAPSHOT
+    assert created_tracked_policy.last_checked_at == checked_at
+
+    with pytest.raises(DuplicateTrackedPolicyError):
+        service.create_tracked_policy(
+            subject=subject,
+            source_url="https://Example.com:443/terms?a=1&b=2#fragment",
+        )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    working_dir: /app
+    volumes:
+      - ./backend:/app
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    depends_on:
+      - backend
+    working_dir: /app
+    volumes:
+      - ./frontend:/app
+      - frontend_node_modules:/app/node_modules
+    ports:
+      - "5173:5173"
+
+volumes:
+  frontend_node_modules:

--- a/docs/SCRUM-10-handoff.md
+++ b/docs/SCRUM-10-handoff.md
@@ -1,0 +1,536 @@
+# SCRUM-10 Handoff
+
+Updated: March 25, 2026  
+Scope: Abuse protection, edge/deployment shaping, Gemini input budgeting, dashboard UX fixes, Docker support, helper scripts, CI/tooling verification, and associated documentation.
+
+This handoff is the implementation-oriented reference for the SCRUM-10 work completed in this repository. When this document conflicts with older notes, current code wins.
+
+## 1. Executive summary
+
+SCRUM-10 was a hardening pass across the full stack rather than a single isolated feature. The completed work covers:
+
+- Input validation and sanitization across backend, frontend, and extension entry points.
+- Abuse protection through backend rate limiting and client-side auth attempt throttling.
+- Gemini free-tier prompt-budget enforcement and a matching dashboard character-limit UX.
+- Cloudflare Worker edge routing in front of the Render backend.
+- Dockerized local development support, helper scripts, CI/tooling validation, and expanded documentation.
+- Dashboard layout regression fixes for analysis cards and saved report history containment.
+
+The system remains a Cloudflare + Render + Supabase architecture:
+
+- Cloudflare Workers: frontend static asset serving plus `/api/*` edge proxy.
+- Render: FastAPI backend origin.
+- Supabase: auth and Postgres persistence.
+
+## 2. Architectural outcomes
+
+### 2.1 Security/input boundary
+
+Before SCRUM-10, the application had multiple input paths that were functional but not uniformly hardened. This pass centralized and propagated sanitization rules so they run before data reaches persistence, remote-fetch logic, or provider calls.
+
+Primary backend boundary:
+
+- `backend/app/core/input_validation.py`
+
+Primary frontend boundary:
+
+- `frontend/src/lib/security/inputValidation.ts`
+
+These boundaries are now reused by:
+
+- backend request schemas and submission preparation
+- frontend API payload creation
+- frontend auth credential normalization
+- extension runtime auth client credential handling
+
+### 2.2 Abuse-protection model
+
+Protection is intentionally layered:
+
+- App-level backend limits:
+  - always enforceable at the FastAPI layer
+  - protect the API even if a caller bypasses the frontend
+- Client-side auth throttling:
+  - slows repeated login/signup attempts in shipped clients
+  - not a replacement for backend or edge controls
+- Cloudflare edge:
+  - proxies deployed API traffic
+  - preserves the forwarding metadata needed for backend limits
+  - still the right place to add WAF or bot controls later
+
+### 2.3 Deployment model clarification
+
+One of the most important clarifications from this work is that Cloudflare and Render do not play the same role:
+
+- Cloudflare Worker code runs at the edge.
+- Render does not execute the Worker code.
+- Render remains the long-running backend origin service.
+
+This means "using edge functions" in this repo really means:
+
+1. browser requests hit the Cloudflare-hosted frontend
+2. `/api/*` requests are intercepted by the Worker
+3. the Worker proxies to `API_BACKEND_ORIGIN`
+4. the Render FastAPI service handles the real business logic
+
+## 3. Detailed implementation areas
+
+### 3.1 Input validation and sanitization
+
+#### Backend
+
+Core normalization and rejection rules live in:
+
+- `backend/app/core/input_validation.py`
+
+This module now handles:
+
+- single-line normalization for titles and emails
+- terms-text normalization
+- unsafe HTML/script-like block stripping
+- control-character rejection/cleanup
+- public-hostname URL validation for external fetch inputs
+- length and blank-value enforcement
+- agreement timestamp validation
+
+These validators are applied in:
+
+- `backend/app/schemas/agreements.py`
+- `backend/app/schemas/reports.py`
+- `backend/app/services/submission_preparation.py`
+
+Practical impact:
+
+- malformed or hostile input is rejected early
+- source URLs cannot target local/private hosts
+- oversized terms input is rejected consistently
+- backend storage and provider calls receive normalized text instead of raw untrusted strings
+
+#### Frontend
+
+Matching client-side validation lives in:
+
+- `frontend/src/lib/security/inputValidation.ts`
+
+This file now sanitizes:
+
+- report-analysis payloads
+- agreement-create payloads
+- terms text
+- optional single-line inputs
+- source URLs
+- email/password credentials
+
+The frontend uses those rules in:
+
+- `frontend/src/lib/api/client.ts`
+- `frontend/src/lib/auth/supabaseClient.ts`
+- `frontend/src/features/dashboard/components/AgreementSubmissionForm.tsx`
+
+#### Extension
+
+The extension now reuses the same auth/input rules through:
+
+- `extension/lib/runtimeAuthClient.ts`
+
+This keeps credential validation consistent between web auth and extension auth instead of maintaining a second set of rules.
+
+### 3.2 Rate limiting and bot resistance
+
+Primary backend rate-limiting implementation:
+
+- `backend/app/security/rate_limit.py`
+
+Wiring:
+
+- `backend/app/api/deps.py`
+- `backend/app/main.py`
+
+Configuration:
+
+- `backend/app/core/config.py`
+- `backend/.env.example`
+- `backend/.env.production.example`
+
+Current default policy families include:
+
+- general API request budget
+- agreement creation budget
+- analysis request budget
+- hourly analysis budget
+
+The design uses policy objects and a sliding-window store so limits can be tuned without changing route code.
+
+Why this matters:
+
+- repeated report listing, submission, or analysis requests can now be throttled
+- abuse is limited even when requests do not come from the browser UI
+- responses include rate-limit headers that make operator debugging easier
+
+Client-side auth throttling:
+
+- `frontend/src/lib/security/authAttemptThrottle.ts`
+- `frontend/src/lib/auth/supabaseClient.ts`
+- `frontend/tests/supabaseClient.rateLimit.test.ts`
+
+This protects sign-in/sign-up flows in the shipped frontend, and similar auth normalization exists in the extension runtime adapter. It is additive protection, not a substitute for backend enforcement.
+
+### 3.3 Gemini free-tier prompt budgeting
+
+Backend runtime/config side:
+
+- `backend/app/core/config.py`
+- `backend/app/services/ai_provider.py`
+
+Important defaults:
+
+- model target: `gemini-2.5-flash`
+- configured free-tier budget: `250000` input tokens
+- conservative estimate: `3` characters per token
+
+The implementation estimates prompt size before making a provider request and raises a structured input error when the configured budget would be exceeded. This avoids wasting a network round trip on obviously too-large requests.
+
+Covered by tests in:
+
+- `backend/tests/test_ai_provider_contract.py`
+- `backend/tests/test_reports_api.py`
+- `backend/tests/test_agreements_api.py`
+
+### 3.4 Dashboard character-limit UX
+
+The backend guard alone was not enough because users could still paste a huge terms document and only discover the failure after submit.
+
+UI changes live in:
+
+- `frontend/src/features/dashboard/components/AgreementSubmissionForm.tsx`
+- `frontend/src/styles/global.css`
+- `frontend/tests/dashboard.test.tsx`
+
+What the dashboard now does:
+
+- shows a live `typed / max` character counter under the terms textarea
+- highlights the counter and textarea when the cap is reached/exceeded
+- disables `Analyze and save report` while the input is oversized
+- shows a tooltip reason on the disabled action wrapper
+- displays inline limit-state messaging explaining the exact overage
+
+Current UI cap:
+
+- `200000` characters
+
+Reasoning:
+
+- it is conservative relative to the backend token estimator and keeps the user-facing limit understandable
+
+### 3.5 Cloudflare Worker edge proxy
+
+Worker implementation:
+
+- `frontend/worker/index.ts`
+
+Worker configuration:
+
+- `frontend/wrangler.jsonc`
+
+Frontend routing behavior:
+
+- `frontend/src/lib/api/createDashboardApiClient.ts`
+
+The Worker currently does three things:
+
+1. intercepts `/api/*`
+2. forwards requests to the configured Render backend origin
+3. serves SPA assets for non-API traffic through `env.ASSETS.fetch(request)`
+
+Important design boundaries:
+
+- the Worker does not duplicate backend business rules
+- backend auth, validation, persistence, and analysis still live in FastAPI
+- forwarded IP/host/proto metadata is preserved so backend rate limiting stays meaningful
+
+Important deployment rule:
+
+- if `VITE_API_BASE_URL` points directly to Render in production, you bypass the Worker
+- the intended deployed default is the same-origin `/api/v1` path so the Cloudflare edge proxy is used
+
+### 3.6 Dashboard layout regression fixes
+
+This hardening work also surfaced several desktop overflow issues in the dashboard.
+
+Fixed areas:
+
+- analysis summary panel overlap
+- flagged clauses panel overlap
+- saved reports history rows extending past the panel edge
+
+Relevant files:
+
+- `frontend/src/styles/global.css`
+- `frontend/src/features/dashboard/components/AgreementSubmissionForm.tsx`
+- `frontend/src/features/dashboard/components/ReportHistoryList.tsx`
+
+Key fixes:
+
+- rebalanced two-column dashboard grid
+- increased dashboard container width modestly
+- earlier single-column collapse breakpoint
+- stronger `min-width: 0` handling on panels, history rows, and truncated content
+- explicit flex-shrink control for status chips and long URLs
+
+### 3.7 Docker support and local developer ergonomics
+
+Added:
+
+- `backend/Dockerfile`
+- `frontend/Dockerfile`
+- `docker-compose.yml`
+
+Design intent:
+
+- mirror the existing local development flow instead of inventing a separate production-like container stack
+
+Current compose/dev behavior:
+
+- backend runs reloadable FastAPI/Uvicorn
+- frontend runs the Vite dev server
+- frontend dependencies are preserved in a volume-compatible way for local iteration
+
+Supporting scripts added/updated:
+
+- `scripts/dev.ps1`
+- `scripts/dev.sh`
+- `scripts/bootstrap.ps1`
+- `scripts/bootstrap.sh`
+
+These helpers now cover:
+
+- running backend/frontend/preview/docker
+- rebuilding backend/frontend/extension/all/docker
+- installing extension dependencies during bootstrap
+
+### 3.8 CI and documentation updates
+
+CI:
+
+- `.github/workflows/ci.yml`
+
+Documentation:
+
+- `README.md`
+- `docs/render-cloudflare-deploy.md`
+- `SCRUM-10-PR.md`
+- `docs/SCRUM-10-handoff.md`
+
+Tooling validation now includes:
+
+- docker compose config validation
+- helper-script validation
+- updated command references for development, testing, and deployment
+
+## 4. Key file map
+
+Use this as the quickest code-navigation index for SCRUM-10:
+
+- Backend validation:
+  - `backend/app/core/input_validation.py`
+  - `backend/app/schemas/agreements.py`
+  - `backend/app/schemas/reports.py`
+  - `backend/app/services/submission_preparation.py`
+- Backend rate limiting:
+  - `backend/app/security/rate_limit.py`
+  - `backend/app/api/deps.py`
+  - `backend/app/main.py`
+  - `backend/tests/test_rate_limiting.py`
+- Gemini budgeting:
+  - `backend/app/core/config.py`
+  - `backend/app/services/ai_provider.py`
+  - `backend/tests/test_ai_provider_contract.py`
+  - `backend/tests/test_reports_api.py`
+  - `backend/tests/test_agreements_api.py`
+- Frontend validation and UX:
+  - `frontend/src/lib/security/inputValidation.ts`
+  - `frontend/src/lib/security/authAttemptThrottle.ts`
+  - `frontend/src/lib/api/client.ts`
+  - `frontend/src/features/dashboard/components/AgreementSubmissionForm.tsx`
+  - `frontend/src/styles/global.css`
+  - `frontend/tests/dashboard.test.tsx`
+- Extension:
+  - `extension/lib/runtimeAuthClient.ts`
+- Edge/deployment:
+  - `frontend/worker/index.ts`
+  - `frontend/wrangler.jsonc`
+  - `frontend/src/lib/api/createDashboardApiClient.ts`
+  - `docs/render-cloudflare-deploy.md`
+- Docker/dev:
+  - `backend/Dockerfile`
+  - `frontend/Dockerfile`
+  - `docker-compose.yml`
+  - `scripts/dev.ps1`
+  - `scripts/dev.sh`
+
+## 5. Verification history
+
+The following commands were run during the SCRUM-10 implementation sequence:
+
+Backend/API/provider coverage:
+
+```bash
+./.venv/Scripts/python.exe -m pytest backend/tests/test_reports_api.py backend/tests/test_agreements_api.py -q
+./.venv/Scripts/python.exe -m pytest backend/tests/test_ai_provider_contract.py backend/tests/test_reports_api.py backend/tests/test_agreements_api.py -q
+./.venv/Scripts/python.exe -m pytest backend/tests/test_rate_limiting.py -q
+```
+
+Frontend and dashboard coverage:
+
+```bash
+npm run test:frontend
+npm run build:frontend
+```
+
+Extension coverage:
+
+```bash
+npm --prefix extension test -- --pool=threads runtimeAuthClient.test.ts
+npm run typecheck:extension
+npm run test:extension
+```
+
+Tooling verification:
+
+```bash
+docker compose config
+npm run verify:docker
+./scripts/dev.ps1 help
+```
+
+Not fully completed in the sandbox:
+
+- `bash -n scripts/dev.sh`
+  - blocked by local Bash access issues in this environment
+- `npm run build:extension`
+  - hit `spawn EPERM` from esbuild in the sandbox
+- `docker compose build backend frontend`
+  - blocked by Docker buildx lock-file access in this environment
+- Black / ESLint / other formatting or lint checks
+  - intentionally not run during implementation because the user explicitly forbade those checks
+
+## 6. Local runbook
+
+### Standard local app run
+
+From the repo root:
+
+```bash
+./scripts/dev.sh run backend
+./scripts/dev.sh run frontend
+```
+
+### Dockerized local run
+
+```bash
+./scripts/dev.sh run docker
+```
+
+### Useful rebuild flows
+
+```bash
+./scripts/dev.sh rebuild backend
+./scripts/dev.sh rebuild frontend
+./scripts/dev.sh rebuild extension
+./scripts/dev.sh rebuild all
+./scripts/dev.sh rebuild docker
+```
+
+## 7. Deployment and runtime notes
+
+### Render
+
+Render is the backend origin runtime.
+
+Important backend environment families:
+
+- Supabase database/auth configuration
+- CORS allow-list
+- abuse-protection rate-limit settings
+- AI provider settings
+
+Important abuse-protection knobs:
+
+- `API_RATE_LIMIT_REQUESTS_PER_WINDOW`
+- `API_RATE_LIMIT_WINDOW_SECONDS`
+- `AGREEMENT_CREATE_RATE_LIMIT_REQUESTS`
+- `AGREEMENT_CREATE_RATE_LIMIT_WINDOW_SECONDS`
+- `ANALYSIS_RATE_LIMIT_REQUESTS`
+- `ANALYSIS_RATE_LIMIT_WINDOW_SECONDS`
+- `ANALYSIS_HOURLY_RATE_LIMIT_REQUESTS`
+- `ANALYSIS_HOURLY_RATE_LIMIT_WINDOW_SECONDS`
+- `ANALYSIS_GEMINI_MAX_INPUT_TOKENS`
+- `ANALYSIS_GEMINI_ESTIMATED_CHARS_PER_TOKEN`
+
+### Cloudflare Workers
+
+Cloudflare is the edge runtime and frontend host.
+
+Required runtime variable:
+
+- `API_BACKEND_ORIGIN=https://<your-render-service>.onrender.com`
+
+Important reminder:
+
+- do not set a deployed `VITE_API_BASE_URL` to the Render origin unless you intentionally want to bypass the Worker proxy
+
+### Supabase
+
+Supabase remains:
+
+- auth issuer/JWT source
+- database backing store
+
+Make sure its redirect allow-list includes:
+
+- local frontend origin(s)
+- deployed Cloudflare Worker origin
+- any custom domain you place in front of Cloudflare
+
+## 8. Risks, limitations, and follow-up work
+
+Current limitations:
+
+- client-side auth throttling is helpful but not authoritative
+- no dedicated WAF/bot-management rules are encoded in repo config yet
+- no queued async analysis infrastructure exists yet
+- dashboard character limits are conservative and based on the current Gemini free-tier assumptions
+- Docker support still needs a full non-sandbox browser smoke test
+
+Recommended follow-ups:
+
+- add Cloudflare WAF / bot / challenge rules once traffic patterns are known
+- add visual regression coverage for dashboard layout containment
+- consider a provider-side `countTokens` path if tighter Gemini sizing becomes necessary
+- add production observability for rate-limit violations and provider rejections
+- consider per-authenticated-user auth-attempt protections on the backend if login abuse remains a concern
+
+## 9. Suggested reviewer/operator checklist
+
+Before calling SCRUM-10 fully done in a live environment:
+
+- confirm deployed frontend requests use `/api/v1` on the Cloudflare origin
+- confirm `API_BACKEND_ORIGIN` points to the correct Render backend
+- confirm backend rate-limit settings are not accidentally zeroed/disabled
+- confirm Supabase redirect origins and CORS values match the live frontend host
+- confirm the terms-text limit UX is visible and the disabled submit state behaves as expected
+- confirm long saved-report URLs truncate cleanly in the dashboard
+- run a real local or deployed Docker smoke test outside this sandbox
+
+## 10. Bottom line
+
+SCRUM-10 materially improved the project's operational baseline. The codebase now has:
+
+- stricter trust boundaries
+- meaningful rate limiting
+- clearer Cloudflare/Render architecture
+- explicit Gemini-size protection
+- better dashboard resilience
+- a documented Docker/dev path
+
+It is still an MVP, but it is a far safer and more operable MVP than the pre-SCRUM-10 state.

--- a/docs/render-cloudflare-deploy.md
+++ b/docs/render-cloudflare-deploy.md
@@ -1,9 +1,9 @@
-# Render + Cloudflare Pages Deployment Runbook
+# Render + Cloudflare Workers Deployment Runbook
 
 This runbook turns the repo into the deployment shape described in `DEPLOYMENT.md`:
 
 - FastAPI backend on Render
-- React frontend on Cloudflare Pages
+- React frontend on Cloudflare Workers static assets
 - Supabase for Postgres and auth
 
 ## Backend on Render
@@ -24,7 +24,8 @@ Set these Render environment variables before first real use:
 - `PERSISTENCE_BACKEND=postgres`
 - `SUPABASE_DATABASE_URL=<your-supabase-postgres-connection-string>` or `DATABASE_URL=...`
 - `SUPABASE_URL=https://<your-project-ref>.supabase.co`
-- `CORS_ALLOWED_ORIGINS=https://<your-project>.pages.dev[,https://<your-custom-domain>]`
+- `CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173[,chrome-extension://<your-extension-id>]`
+- Rate-limit defaults are enabled in the backend; tune `API_RATE_LIMIT_*`, `AGREEMENT_CREATE_RATE_LIMIT_*`, and `ANALYSIS_*RATE_LIMIT*` in Render if your demo traffic needs a different budget.
 
 Set these auth variables if you are not relying on the `SUPABASE_URL` derived defaults:
 
@@ -36,32 +37,33 @@ Set these analysis variables only if you want hosted AI-backed analysis instead 
 
 - `ANALYSIS_PROVIDER_MODE=ai`
 - `ANALYSIS_AI_PROVIDER_KIND=gemini` or `openai_compatible`
-- `ANALYSIS_GEMINI_API_KEY` and `ANALYSIS_GEMINI_MODEL`
+- `ANALYSIS_GEMINI_API_KEY` and `ANALYSIS_GEMINI_MODEL=gemini-2.5-flash`
+- Optional Gemini budget overrides: `ANALYSIS_GEMINI_MAX_INPUT_TOKENS` and `ANALYSIS_GEMINI_ESTIMATED_CHARS_PER_TOKEN`
 - `ANALYSIS_OPENAI_COMPATIBLE_API_KEY` and `ANALYSIS_OPENAI_COMPATIBLE_MODEL`
 
-## Frontend on Cloudflare Pages
+## Frontend on Cloudflare Workers
 
-Use `frontend` as the Pages root directory. This repo has a root `pyproject.toml`, and if Pages builds from the repository root it will auto-detect Python and try `pip install .`, which breaks the frontend deploy.
+The frontend is deployed with `wrangler deploy`, not Cloudflare Pages. The `frontend/wrangler.jsonc` file now includes a Worker entrypoint that proxies `/api/*` traffic to Render while serving the SPA bundle from Cloudflare static assets.
 
-Recommended Pages settings:
+Use these deployment/runtime inputs:
 
-- Framework preset: `React (Vite)` or `None`
-- Root directory: `frontend`
+- Working directory: `frontend`
 - Build command: `npm run build`
-- Build output directory: `dist`
+- Deploy command: `npm run deploy`
+- Worker runtime variable: `API_BACKEND_ORIGIN=https://<your-render-service>.onrender.com`
 
 Important:
 
-- Do not use the repo-root workspace command `npm run build:frontend` once the Pages root is `frontend`.
-- From inside `frontend`, the available script is `npm run build`.
-- If Cloudflare prefilled an old build command, overwrite it manually.
+- The browser app now defaults to the same-origin edge proxy at `/api/v1` when `VITE_API_BASE_URL` is unset in deployed builds.
+- `API_BACKEND_ORIGIN` must point at the Render service origin without rewriting the `/api/v1` path segment.
+- Local Vite dev still talks directly to `http://127.0.0.1:8000/api/v1` unless you override `VITE_API_BASE_URL`.
 
-Set these Cloudflare Pages environment variables:
+Set these Cloudflare Workers/Vite environment variables:
 
-- `VITE_API_BASE_URL=https://<your-render-service>.onrender.com/api/v1`
 - `VITE_SUPABASE_URL=https://<your-project-ref>.supabase.co`
 - `VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>`
 - Optional: `NODE_VERSION=22.16.0` or any version compatible with the repo's `>=20.19.0` requirement
+- Optional browser override only if you intentionally want to bypass the edge proxy: `VITE_API_BASE_URL=https://<your-render-service>.onrender.com/api/v1`
 
 Do not add a `_redirects` file for this Cloudflare deploy path. Current Wrangler/Workers SPA deploys already use `assets.not_found_handling = "single-page-application"`, and combining that with `/* /index.html 200` causes Cloudflare validation error `10021` for an infinite redirect loop.
 
@@ -81,10 +83,11 @@ Use `frontend/.env.production.example` as the reference if you want to create a 
 Before calling the deployment done, verify all of this:
 
 - Render health check responds at `/health`
-- Cloudflare Pages build succeeds and serves `frontend/dist`
-- `VITE_API_BASE_URL` points at the Render backend, not localhost
-- Render `CORS_ALLOWED_ORIGINS` includes every deployed frontend origin
-- Supabase Auth redirect allow-list includes the Cloudflare Pages URL and any custom domain
+- Cloudflare deploy succeeds and serves `frontend/dist`
+- Cloudflare Worker runtime variable `API_BACKEND_ORIGIN` points at the Render backend origin
+- Deployed browser requests hit `/api/v1/*` on the Cloudflare origin instead of calling Render directly
+- Abuse-protection env vars are set to sane values for demo traffic and not disabled with `0`
+- Supabase Auth redirect allow-list includes the Cloudflare Worker URL and any custom domain
 - No `_redirects` file is being uploaded alongside a Wrangler SPA deploy
 
 ## Secret Handling
@@ -92,5 +95,7 @@ Before calling the deployment done, verify all of this:
 Do not commit real deployment secrets to the repo. Keep live values in:
 
 - Render environment variables for backend secrets and backend runtime config
-- Cloudflare Pages environment variables for frontend build-time values
+- Cloudflare Workers environment variables for `API_BACKEND_ORIGIN` and frontend build-time values
 - Local untracked `.env` files only for local development
+
+Cloudflare edge protections should still be layered on top of the app-level rate limits when you do a real deployment. The backend limits protect the API itself; Cloudflare remains the right place for broader bot/WAF controls at the edge.

--- a/docs/render-cloudflare-deploy.md
+++ b/docs/render-cloudflare-deploy.md
@@ -24,7 +24,7 @@ Set these Render environment variables before first real use:
 - `PERSISTENCE_BACKEND=postgres`
 - `SUPABASE_DATABASE_URL=<your-supabase-postgres-connection-string>` or `DATABASE_URL=...`
 - `SUPABASE_URL=https://<your-project-ref>.supabase.co`
-- `CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173[,chrome-extension://<your-extension-id>]`
+- `CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://localhost:4173,http://127.0.0.1:4173[,chrome-extension://<your-extension-id>]`
 - Rate-limit defaults are enabled in the backend; tune `API_RATE_LIMIT_*`, `AGREEMENT_CREATE_RATE_LIMIT_*`, and `ANALYSIS_*RATE_LIMIT*` in Render if your demo traffic needs a different budget.
 
 Set these auth variables if you are not relying on the `SUPABASE_URL` derived defaults:

--- a/extension/lib/runtimeAuthClient.ts
+++ b/extension/lib/runtimeAuthClient.ts
@@ -7,6 +7,15 @@ import {
   AUTH_PROVIDER_GOOGLE,
   normalizeProviderSignInError,
 } from "../../frontend/src/lib/auth/providerErrors";
+import {
+  AuthAttemptThrottle,
+  type AuthAttemptThrottleState,
+  type AuthAttemptThrottleStore,
+  PASSWORD_SIGN_IN_ATTEMPT_POLICY,
+  PASSWORD_SIGN_UP_ATTEMPT_POLICY,
+  normalizeAuthAttemptIdentifier,
+} from "../../frontend/src/lib/security/authAttemptThrottle";
+import { sanitizePasswordCredentials } from "../../frontend/src/lib/security/inputValidation";
 import { resolveSupabaseAuthConfig } from "./runtimeAuth/config";
 import { launchGooglePkceOAuthFlow } from "./runtimeAuth/oauthGoogle";
 import { extractSignUpTokenPayload, isExpired } from "./runtimeAuth/sessionCodec";
@@ -38,6 +47,17 @@ import type {
  * - authenticated backend calls return 401 and should trigger one refresh retry
  */
 export class ExtensionRuntimeAuthClient implements AuthClient {
+  private readonly signInAttemptThrottle = new AuthAttemptThrottle({
+    policy: PASSWORD_SIGN_IN_ATTEMPT_POLICY,
+    store: createChromeStorageThrottleStore(),
+    keyPrefix: "extension_auth_attempts",
+  });
+  private readonly signUpAttemptThrottle = new AuthAttemptThrottle({
+    policy: PASSWORD_SIGN_UP_ATTEMPT_POLICY,
+    store: createChromeStorageThrottleStore(),
+    keyPrefix: "extension_auth_attempts",
+  });
+
   async getSession(): Promise<AuthenticatedSession | null> {
     const session = await readStoredSession();
     if (!session) {
@@ -59,7 +79,11 @@ export class ExtensionRuntimeAuthClient implements AuthClient {
 
   async signInWithPassword(credentials: PasswordCredentials): Promise<void> {
     const config = await resolveSupabaseAuthConfig();
-    const normalizedCredentials = normalizeCredentials(credentials);
+    const normalizedCredentials = normalizeCredentials(
+      sanitizePasswordCredentials(credentials),
+    );
+    const normalizedEmail = normalizeAuthAttemptIdentifier(normalizedCredentials.email);
+    await this.signInAttemptThrottle.registerAttempt(normalizedEmail);
 
     const tokenPayload = await requestSupabaseJson<SupabaseTokenPayload>({
       config,
@@ -70,11 +94,17 @@ export class ExtensionRuntimeAuthClient implements AuthClient {
     });
 
     await persistSessionFromTokenPayload(tokenPayload);
+    await this.signInAttemptThrottle.clear(normalizedEmail);
   }
 
   async signUpWithPassword(credentials: PasswordCredentials): Promise<void> {
     const config = await resolveSupabaseAuthConfig();
-    const normalizedCredentials = normalizeCredentials(credentials);
+    const normalizedCredentials = normalizeCredentials(
+      sanitizePasswordCredentials(credentials),
+    );
+    await this.signUpAttemptThrottle.registerAttempt(
+      normalizeAuthAttemptIdentifier(normalizedCredentials.email),
+    );
 
     const signUpPayload = await requestSupabaseJson<SupabaseSignUpPayload>({
       config,
@@ -172,4 +202,25 @@ function toActionableGoogleSignInMessage(normalizedMessage: string, rawMessage: 
     return "Google sign-in failed because Supabase rejected the OAuth callback. Verify extension redirect allow-list and use PKCE callback URL exactly: https://<extension-id>.chromiumapp.org/supabase-auth.";
   }
   return normalizedMessage;
+}
+
+function createChromeStorageThrottleStore(): AuthAttemptThrottleStore {
+  return {
+    async read(key: string): Promise<AuthAttemptThrottleState | null> {
+      const stored = await chrome.storage.local.get(key);
+      const candidate = stored[key];
+      if (!candidate || typeof candidate !== "object") {
+        return null;
+      }
+
+      const state = candidate as AuthAttemptThrottleState;
+      return Array.isArray(state.attemptTimestamps) ? state : null;
+    },
+    async write(key: string, state: AuthAttemptThrottleState): Promise<void> {
+      await chrome.storage.local.set({ [key]: state });
+    },
+    async remove(key: string): Promise<void> {
+      await chrome.storage.local.remove(key);
+    },
+  };
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "node ./scripts/build.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test": "vitest run --environment jsdom"
+    "test": "vitest run --environment jsdom --pool=threads"
   },
   "devDependencies": {
     "@types/chrome": "^0.1.30",

--- a/extension/tests/runtimeAuthClient.test.ts
+++ b/extension/tests/runtimeAuthClient.test.ts
@@ -147,6 +147,60 @@ describe("extension runtime auth client", () => {
     expect(localStorageState.auth_refresh_token).toBe("password-refresh-token");
   });
 
+  it("blocks repeated password sign-in attempts before calling Supabase again", async () => {
+    installChromeMocks({
+      auth_supabase_url: SUPABASE_URL,
+      auth_supabase_anon_key: SUPABASE_ANON_KEY,
+    });
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/auth/v1/token?grant_type=password")) {
+        return jsonResponse({ message: "Invalid login credentials." }, 400);
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ExtensionRuntimeAuthClient();
+    const credentials = {
+      email: "password-user@example.com",
+      password: "wrong-password",
+    };
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await expect(client.signInWithPassword(credentials)).rejects.toThrow(
+        "Invalid login credentials.",
+      );
+    }
+
+    await expect(client.signInWithPassword(credentials)).rejects.toThrow(
+      "Too many sign-in attempts.",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  it("rejects invalid password credentials before calling Supabase", async () => {
+    installChromeMocks({
+      auth_supabase_url: SUPABASE_URL,
+      auth_supabase_anon_key: SUPABASE_ANON_KEY,
+    });
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ExtensionRuntimeAuthClient();
+
+    await expect(
+      client.signInWithPassword({
+        email: "bad-email",
+        password: "short",
+      }),
+    ).rejects.toThrow("Email address is invalid.");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("clears local auth_session on signOut even if provider logout fails", async () => {
     const { localStorageState } = installChromeMocks({
       auth_supabase_url: SUPABASE_URL,

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -5,7 +5,7 @@
 # - your backend runs on a different host/port
 # - you prefer 127.0.0.1 over localhost
 # - you point frontend to a remote/dev backend
-# - you are wiring Cloudflare Pages to a Render backend
+# - you want to bypass the default Cloudflare Worker edge proxy in deployed builds
 VITE_API_BASE_URL=http://127.0.0.1:8000/api/v1
 
 # Supabase auth client config (required for login flow)
@@ -13,7 +13,7 @@ VITE_API_BASE_URL=http://127.0.0.1:8000/api/v1
 # Example URL: https://your-project-ref.supabase.co
 # These are also required when using the web app to obtain a real JWT session
 # for local extension runtime testing.
-# In Cloudflare Pages, set these as project environment variables instead of
+# In Cloudflare Workers/Vite deploys, set these as project environment variables instead of
 # committing populated values to source control.
 # Google sign-in also requires provider enablement + redirect allow-list setup.
 # See docs/google-auth-setup-matrix.md.

--- a/frontend/.env.production.example
+++ b/frontend/.env.production.example
@@ -3,13 +3,16 @@
 # If you want a local production build preview, copy this file to
 # `frontend/.env.production` and replace the placeholders.
 
-# Backend API URL served from Render.
-# Example: https://terms-and-conditions-analyzer-api.onrender.com/api/v1
-VITE_API_BASE_URL=https://your-render-service.onrender.com/api/v1
+# Optional browser-side API override.
+# Leave this unset to use the same-origin Cloudflare Worker edge proxy at `/api/v1`.
+# Only set it if you intentionally want the browser to call Render directly.
+# VITE_API_BASE_URL=https://your-render-service.onrender.com/api/v1
 
 # Supabase browser auth configuration.
 VITE_SUPABASE_URL=https://your-project-ref.supabase.co
 
 # Supabase anon key is safe for client-side use, but keep real values in
-# Cloudflare Pages environment variables instead of committing them.
+# Cloudflare Workers/Vite environment variables instead of committing them.
+# The Worker runtime variable `API_BACKEND_ORIGIN` belongs in Cloudflare
+# Workers configuration, not in this Vite env file.
 VITE_SUPABASE_ANON_KEY=your-supabase-anon-key

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,17 @@
+# Development-focused frontend image for local docker-compose use.
+# It mirrors the current local workflow by running the Vite dev server and
+# expecting the project source to be bind-mounted at runtime.
+
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+
+ENV CHOKIDAR_USEPOLLING=true
+
+COPY package.json ./package.json
+
+RUN npm install --no-audit --no-fund
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,11 +5,14 @@
 
 import { AuthProvider } from './features/auth/AuthProvider';
 import { AuthEntryPoint } from './features/auth/AuthEntryPoint';
+import { ThemeProvider } from './features/theme/ThemeProvider';
 
 export function App() {
   return (
-    <AuthProvider>
-      <AuthEntryPoint />
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <AuthEntryPoint />
+      </AuthProvider>
+    </ThemeProvider>
   );
 }

--- a/frontend/src/features/auth/AuthEntryPoint.tsx
+++ b/frontend/src/features/auth/AuthEntryPoint.tsx
@@ -15,6 +15,7 @@ import { useMemo, useState } from 'react';
 import { PanelStateMessage } from '../../components/ui/PanelStateMessage';
 import { createDashboardApiClient } from '../../lib/api/createDashboardApiClient';
 import { DashboardPage } from '../dashboard/DashboardPage';
+import { ThemeToggleButton } from '../theme/ThemeToggleButton';
 import { useAuth } from './AuthProvider';
 import { LoginScreen } from './components/LoginScreen';
 
@@ -81,16 +82,19 @@ export function AuthEntryPoint() {
       apiClient={dashboardApiClient}
       contextLabel={state.session?.email ? `Signed in as ${state.session.email}` : null}
       headerAction={
-        <button
-          type="button"
-          className="button-secondary"
-          onClick={() => {
-            void runSubmittingAction(() => signOut());
-          }}
-          disabled={isSubmitting}
-        >
-          Sign out
-        </button>
+        <>
+          <ThemeToggleButton />
+          <button
+            type="button"
+            className="button-secondary"
+            onClick={() => {
+              void runSubmittingAction(() => signOut());
+            }}
+            disabled={isSubmitting}
+          >
+            Sign out
+          </button>
+        </>
       }
     />
   );

--- a/frontend/src/features/auth/components/LoginScreen.tsx
+++ b/frontend/src/features/auth/components/LoginScreen.tsx
@@ -102,6 +102,7 @@ export function LoginScreen({
               value={email}
               onChange={(event) => setEmail(event.target.value)}
               autoComplete="email"
+              maxLength={320}
               required
             />
           </label>
@@ -113,6 +114,8 @@ export function LoginScreen({
               value={password}
               onChange={(event) => setPassword(event.target.value)}
               autoComplete={modeCopy.passwordAutocomplete}
+              minLength={8}
+              maxLength={128}
               required
             />
           </label>

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -13,7 +13,9 @@ import { AgreementSubmissionForm } from './components/AgreementSubmissionForm';
 import { AnalysisSummaryCard } from './components/AnalysisSummaryCard';
 import { FlaggedClausesList } from './components/FlaggedClausesList';
 import { ReportHistoryList } from './components/ReportHistoryList';
+import { TrackedPolicyWatchlistPanel } from './components/TrackedPolicyWatchlistPanel';
 import { useDashboardReports } from './hooks/useDashboardReports';
+import { useTrackedPolicies } from './hooks/useTrackedPolicies';
 
 interface DashboardPageProps {
   // Optional injection seam for tests and auth-aware wrappers.
@@ -37,17 +39,33 @@ export function DashboardPage({
     isSubmitting,
     isLoadingHistory,
     isLoadingReport,
-    errorMessage,
-    successMessage,
+    errorMessage: reportErrorMessage,
+    successMessage: reportSuccessMessage,
     submitAndAnalyze,
     loadReportHistory,
     selectReport,
-    clearMessages,
+    clearMessages: clearReportMessages,
   } = useDashboardReports(effectiveApiClient);
+  const {
+    trackedPolicies,
+    isLoadingTrackedPolicies,
+    isCreatingTrackedPolicy,
+    removingTrackedPolicyId,
+    errorMessage: trackedPolicyErrorMessage,
+    successMessage: trackedPolicySuccessMessage,
+    loadTrackedPolicies,
+    createTrackedPolicy,
+    removeTrackedPolicy,
+    clearMessages: clearTrackedPolicyMessages,
+  } = useTrackedPolicies(effectiveApiClient);
 
   useEffect(() => {
     void loadReportHistory();
   }, [loadReportHistory]);
+
+  useEffect(() => {
+    void loadTrackedPolicies();
+  }, [loadTrackedPolicies]);
 
   return (
     <main className="dashboard">
@@ -55,28 +73,57 @@ export function DashboardPage({
         <div className="dashboard-header-copy">
           <h1>Terms and Conditions Dashboard</h1>
           <p className="dashboard-subtitle">
-            Submit terms, generate analysis, and review saved reports.
+            Submit terms, review saved reports, and keep a watchlist of policies you want tracked.
           </p>
           {contextLabel ? <p className="dashboard-user">{contextLabel}</p> : null}
         </div>
         {headerAction ? <div className="header-actions">{headerAction}</div> : null}
       </header>
 
-      {errorMessage || successMessage ? (
+      {reportErrorMessage ||
+      reportSuccessMessage ||
+      trackedPolicyErrorMessage ||
+      trackedPolicySuccessMessage ? (
         <section className="dashboard-feedback" aria-live="polite">
-          {errorMessage ? (
+          {reportErrorMessage ? (
             <div className="error-banner" role="alert">
-              <span>{errorMessage}</span>
-              <button type="button" className="button-link" onClick={clearMessages}>
+              <span>{reportErrorMessage}</span>
+              <button type="button" className="button-link" onClick={clearReportMessages}>
                 Dismiss
               </button>
             </div>
           ) : null}
 
-          {successMessage ? (
+          {reportSuccessMessage ? (
             <div className="success-banner" role="status">
-              <span>{successMessage}</span>
-              <button type="button" className="button-link" onClick={clearMessages}>
+              <span>{reportSuccessMessage}</span>
+              <button type="button" className="button-link" onClick={clearReportMessages}>
+                Dismiss
+              </button>
+            </div>
+          ) : null}
+
+          {trackedPolicyErrorMessage ? (
+            <div className="error-banner" role="alert">
+              <span>{trackedPolicyErrorMessage}</span>
+              <button
+                type="button"
+                className="button-link"
+                onClick={clearTrackedPolicyMessages}
+              >
+                Dismiss
+              </button>
+            </div>
+          ) : null}
+
+          {trackedPolicySuccessMessage ? (
+            <div className="success-banner" role="status">
+              <span>{trackedPolicySuccessMessage}</span>
+              <button
+                type="button"
+                className="button-link"
+                onClick={clearTrackedPolicyMessages}
+              >
                 Dismiss
               </button>
             </div>
@@ -88,6 +135,14 @@ export function DashboardPage({
         {/* Left column handles submission + retrieval controls; right column is read-only analysis output. */}
         <div className="dashboard-column dashboard-column-primary">
           <AgreementSubmissionForm onSubmit={submitAndAnalyze} isSubmitting={isSubmitting} />
+          <TrackedPolicyWatchlistPanel
+            trackedPolicies={trackedPolicies}
+            isLoadingTrackedPolicies={isLoadingTrackedPolicies}
+            isCreatingTrackedPolicy={isCreatingTrackedPolicy}
+            removingTrackedPolicyId={removingTrackedPolicyId}
+            onCreateTrackedPolicy={createTrackedPolicy}
+            onRemoveTrackedPolicy={removeTrackedPolicy}
+          />
           <ReportHistoryList
             reports={reportHistory}
             selectedReportId={selectedReport?.id ?? null}

--- a/frontend/src/features/dashboard/components/AgreementSubmissionForm.tsx
+++ b/frontend/src/features/dashboard/components/AgreementSubmissionForm.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useState } from 'react';
 
+import { sanitizeReportAnalyzeInput } from '../../../lib/security/inputValidation';
 import type { DashboardAnalysisInput } from '../types';
 
 interface AgreementSubmissionFormProps {
@@ -16,23 +17,19 @@ export function AgreementSubmissionForm({ onSubmit, isSubmitting }: AgreementSub
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-
-    const normalizedSourceUrl = sourceUrl.trim();
-    const normalizedTermsText = termsText.trim();
-
-    if (!normalizedSourceUrl && !normalizedTermsText) {
-      setFormError('Provide either a source URL or terms text.');
-      return;
+    try {
+      const sanitizedInput = sanitizeReportAnalyzeInput({
+        title: title || null,
+        source_url: sourceUrl || null,
+        // Backend contracts expect ISO datetime strings.
+        agreed_at: agreedAt ? new Date(agreedAt).toISOString() : null,
+        terms_text: termsText || null,
+      });
+      setFormError(null);
+      await onSubmit(sanitizedInput);
+    } catch (error) {
+      setFormError(error instanceof Error ? error.message : 'Submission input is invalid.');
     }
-
-    setFormError(null);
-    await onSubmit({
-      title: title.trim() || null,
-      source_url: normalizedSourceUrl || null,
-      // Backend contracts expect ISO datetime strings.
-      agreed_at: agreedAt ? new Date(agreedAt).toISOString() : null,
-      terms_text: normalizedTermsText || null,
-    });
   };
 
   return (
@@ -51,6 +48,7 @@ export function AgreementSubmissionForm({ onSubmit, isSubmitting }: AgreementSub
             value={title}
             onChange={(event) => setTitle(event.target.value)}
             placeholder="Example: Acme Cloud Terms of Service"
+            maxLength={200}
           />
         </label>
         <label className="field field-compact">
@@ -60,6 +58,7 @@ export function AgreementSubmissionForm({ onSubmit, isSubmitting }: AgreementSub
             value={sourceUrl}
             onChange={(event) => setSourceUrl(event.target.value)}
             placeholder="https://example.com/terms"
+            maxLength={2048}
           />
         </label>
         <label className="field field-compact">
@@ -77,6 +76,7 @@ export function AgreementSubmissionForm({ onSubmit, isSubmitting }: AgreementSub
             onChange={(event) => setTermsText(event.target.value)}
             placeholder="Paste terms and conditions text..."
             rows={9}
+            maxLength={200000}
           />
         </label>
         <p className="field-help field-full">Provide at least one: source URL or terms text.</p>

--- a/frontend/src/features/dashboard/components/AgreementSubmissionForm.tsx
+++ b/frontend/src/features/dashboard/components/AgreementSubmissionForm.tsx
@@ -1,11 +1,22 @@
 import { FormEvent, useState } from 'react';
 
-import { sanitizeReportAnalyzeInput } from '../../../lib/security/inputValidation';
+import {
+  MAX_SOURCE_URL_LENGTH,
+  MAX_TERMS_TEXT_LENGTH,
+  MAX_TITLE_LENGTH,
+  sanitizeReportAnalyzeInput,
+} from '../../../lib/security/inputValidation';
 import type { DashboardAnalysisInput } from '../types';
 
 interface AgreementSubmissionFormProps {
   onSubmit: (input: DashboardAnalysisInput) => Promise<void>;
   isSubmitting: boolean;
+}
+
+const countFormatter = new Intl.NumberFormat('en-US');
+
+function formatCount(value: number): string {
+  return countFormatter.format(value);
 }
 
 export function AgreementSubmissionForm({ onSubmit, isSubmitting }: AgreementSubmissionFormProps) {
@@ -14,9 +25,32 @@ export function AgreementSubmissionForm({ onSubmit, isSubmitting }: AgreementSub
   const [agreedAt, setAgreedAt] = useState('');
   const [termsText, setTermsText] = useState('');
   const [formError, setFormError] = useState<string | null>(null);
+  const termsCharacterCount = termsText.length;
+  const termsCharactersOverLimit = Math.max(termsCharacterCount - MAX_TERMS_TEXT_LENGTH, 0);
+  const hasReachedTermsLimit = termsCharacterCount >= MAX_TERMS_TEXT_LENGTH;
+  const submitBlockedByTermsLimit = hasReachedTermsLimit;
+  const termsLimitMessage =
+    termsCharactersOverLimit > 0
+      ? `You've exceeded the ${formatCount(MAX_TERMS_TEXT_LENGTH)} character limit by ${formatCount(
+          termsCharactersOverLimit,
+        )} characters.`
+      : hasReachedTermsLimit
+        ? `You've reached the ${formatCount(MAX_TERMS_TEXT_LENGTH)} character limit. Shorten the terms text before analyzing.`
+        : null;
+  const submitDisabledReason = submitBlockedByTermsLimit
+    ? termsLimitMessage ?? `Terms text must stay under ${formatCount(MAX_TERMS_TEXT_LENGTH)} characters.`
+    : undefined;
+  const textareaDescriptionIds = ['terms-text-guidance', 'terms-text-counter'];
+  if (termsLimitMessage) {
+    textareaDescriptionIds.push('terms-text-limit-message');
+  }
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (submitBlockedByTermsLimit) {
+      setFormError(null);
+      return;
+    }
     try {
       const sanitizedInput = sanitizeReportAnalyzeInput({
         title: title || null,
@@ -48,7 +82,7 @@ export function AgreementSubmissionForm({ onSubmit, isSubmitting }: AgreementSub
             value={title}
             onChange={(event) => setTitle(event.target.value)}
             placeholder="Example: Acme Cloud Terms of Service"
-            maxLength={200}
+            maxLength={MAX_TITLE_LENGTH}
           />
         </label>
         <label className="field field-compact">
@@ -58,7 +92,7 @@ export function AgreementSubmissionForm({ onSubmit, isSubmitting }: AgreementSub
             value={sourceUrl}
             onChange={(event) => setSourceUrl(event.target.value)}
             placeholder="https://example.com/terms"
-            maxLength={2048}
+            maxLength={MAX_SOURCE_URL_LENGTH}
           />
         </label>
         <label className="field field-compact">
@@ -72,25 +106,52 @@ export function AgreementSubmissionForm({ onSubmit, isSubmitting }: AgreementSub
         <label className="field field-full">
           <span>Terms text</span>
           <textarea
+            aria-describedby={textareaDescriptionIds.join(' ')}
+            aria-invalid={submitBlockedByTermsLimit ? 'true' : undefined}
+            className={hasReachedTermsLimit ? 'field-input-limit' : undefined}
             value={termsText}
             onChange={(event) => setTermsText(event.target.value)}
             placeholder="Paste terms and conditions text..."
             rows={9}
-            maxLength={200000}
           />
         </label>
-        <p className="field-help field-full">Provide at least one: source URL or terms text.</p>
+        <div className="terms-support-row field-full">
+          <p className="field-help" id="terms-text-guidance">
+            Provide at least one: source URL or terms text.
+          </p>
+          <p
+            className={`field-help terms-character-counter${hasReachedTermsLimit ? ' terms-character-counter-limit' : ''}`}
+            id="terms-text-counter"
+            aria-live="polite"
+          >
+            {formatCount(termsCharacterCount)} / {formatCount(MAX_TERMS_TEXT_LENGTH)} characters
+          </p>
+        </div>
+        {termsLimitMessage ? (
+          <p className="inline-error field-full" role="alert" id="terms-text-limit-message">
+            {termsLimitMessage}
+          </p>
+        ) : null}
         {formError ? (
           <p className="inline-error field-full" role="alert">
             {formError}
           </p>
         ) : null}
         <div className="actions submission-actions field-full">
-          <button type="submit" className="button-primary" disabled={isSubmitting}>
-            {isSubmitting ? 'Analyzing...' : 'Analyze and save report'}
-          </button>
+          <span className="button-disabled-wrapper" title={submitDisabledReason}>
+            <button
+              type="submit"
+              className="button-primary"
+              disabled={isSubmitting || submitBlockedByTermsLimit}
+              aria-describedby={termsLimitMessage ? 'terms-text-limit-message' : undefined}
+            >
+              {isSubmitting ? 'Analyzing...' : 'Analyze and save report'}
+            </button>
+          </span>
           <p className="submit-hint">
-            {isSubmitting
+            {submitBlockedByTermsLimit
+              ? 'Trim the submitted terms text to re-enable analysis.'
+              : isSubmitting
               ? 'Generating summary and clause risk analysis.'
               : 'Reports are saved automatically to your history.'}
           </p>

--- a/frontend/src/features/dashboard/components/TrackedPolicyWatchlistPanel.tsx
+++ b/frontend/src/features/dashboard/components/TrackedPolicyWatchlistPanel.tsx
@@ -1,0 +1,136 @@
+import { FormEvent, useState } from 'react';
+
+import { PanelStateMessage } from '../../../components/ui/PanelStateMessage';
+import { sanitizeTrackedPolicyCreateInput } from '../../../lib/security/inputValidation';
+import { formatDashboardDate } from '../presentation/formatDashboardDate';
+import type { DashboardTrackedPolicy } from '../types';
+
+interface TrackedPolicyWatchlistPanelProps {
+  trackedPolicies: DashboardTrackedPolicy[];
+  isLoadingTrackedPolicies: boolean;
+  isCreatingTrackedPolicy: boolean;
+  removingTrackedPolicyId: string | null;
+  onCreateTrackedPolicy: (sourceUrl: string) => Promise<void>;
+  onRemoveTrackedPolicy: (trackedPolicyId: string) => Promise<void>;
+}
+
+function getTrackingStatusChipClassName(trackingStatus: string): string {
+  const normalizedStatus = trackingStatus.toLowerCase();
+  if (normalizedStatus === 'active') {
+    return 'tracking-status-active';
+  }
+  if (normalizedStatus === 'invalid_source') {
+    return 'tracking-status-invalid';
+  }
+  if (normalizedStatus === 'pending_first_snapshot') {
+    return 'tracking-status-pending';
+  }
+  return 'tracking-status-default';
+}
+
+function formatTrackingStatusLabel(trackingStatus: string): string {
+  return trackingStatus.replace(/_/g, ' ');
+}
+
+export function TrackedPolicyWatchlistPanel({
+  trackedPolicies,
+  isLoadingTrackedPolicies,
+  isCreatingTrackedPolicy,
+  removingTrackedPolicyId,
+  onCreateTrackedPolicy,
+  onRemoveTrackedPolicy,
+}: TrackedPolicyWatchlistPanelProps) {
+  const [sourceUrl, setSourceUrl] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    try {
+      const sanitizedInput = sanitizeTrackedPolicyCreateInput({
+        source_url: sourceUrl,
+      });
+      setFormError(null);
+      await onCreateTrackedPolicy(sanitizedInput.source_url);
+      setSourceUrl('');
+    } catch (error) {
+      setFormError(error instanceof Error ? error.message : 'Source URL is invalid.');
+    }
+  };
+
+  return (
+    <section className="panel">
+      <header className="panel-header panel-header-tight">
+        <h2 className="panel-title">Policy Watchlist</h2>
+        <p className="panel-description">
+          Register legal page URLs for ongoing tracking. New entries are verified before they are
+          saved.
+        </p>
+      </header>
+
+      <form className="watchlist-form" onSubmit={handleSubmit}>
+        <label className="field">
+          <span>Policy URL</span>
+          <input
+            type="url"
+            value={sourceUrl}
+            onChange={(event) => setSourceUrl(event.target.value)}
+            placeholder="https://example.com/legal/terms"
+          />
+        </label>
+        <div className="actions watchlist-actions">
+          <button type="submit" className="button-primary" disabled={isCreatingTrackedPolicy}>
+            {isCreatingTrackedPolicy ? 'Adding...' : 'Add to watchlist'}
+          </button>
+          <p className="submit-hint">Only public, readable policy pages can be tracked.</p>
+        </div>
+      </form>
+
+      {formError ? (
+        <p className="inline-error watchlist-inline-error" role="alert">
+          {formError}
+        </p>
+      ) : null}
+
+      {isLoadingTrackedPolicies ? <PanelStateMessage message="Loading watchlist..." /> : null}
+      {!isLoadingTrackedPolicies && trackedPolicies.length === 0 ? (
+        <PanelStateMessage message="No tracked policies yet. Add a policy URL to start monitoring changes." />
+      ) : null}
+
+      <ul className="watchlist-list">
+        {trackedPolicies.map((trackedPolicy) => (
+          <li key={trackedPolicy.id} className="watchlist-row">
+            <div className="watchlist-row-main">
+              <div className="watchlist-row-copy">
+                <strong className="watchlist-display-name">{trackedPolicy.displayName}</strong>
+                <span className="watchlist-url">{trackedPolicy.canonicalUrl}</span>
+                <span className="watchlist-meta">
+                  Last checked{' '}
+                  {trackedPolicy.lastCheckedAt
+                    ? formatDashboardDate(trackedPolicy.lastCheckedAt)
+                    : 'Never'}
+                </span>
+              </div>
+              <span
+                className={`chip watchlist-status-chip ${getTrackingStatusChipClassName(
+                  trackedPolicy.trackingStatus,
+                )}`}
+              >
+                {formatTrackingStatusLabel(trackedPolicy.trackingStatus)}
+              </span>
+            </div>
+            <div className="watchlist-row-actions">
+              <button
+                type="button"
+                className="button-secondary"
+                onClick={() => void onRemoveTrackedPolicy(trackedPolicy.id)}
+                disabled={removingTrackedPolicyId === trackedPolicy.id}
+              >
+                {removingTrackedPolicyId === trackedPolicy.id ? 'Removing...' : 'Remove'}
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/features/dashboard/hooks/useTrackedPolicies.ts
+++ b/frontend/src/features/dashboard/hooks/useTrackedPolicies.ts
@@ -1,0 +1,110 @@
+/* Architecture note:
+ * This hook owns dashboard watchlist state and keeps tracked-policy network
+ * behavior separate from report-analysis state. The dashboard container can
+ * compose both hooks without merging unrelated workflows.
+ */
+
+import { useCallback, useState } from 'react';
+
+import type { DashboardApiClient } from '../../../lib/api/client';
+import { mapTrackedPolicy } from '../mappers';
+import type { DashboardTrackedPolicy } from '../types';
+
+interface UseTrackedPoliciesResult {
+  trackedPolicies: DashboardTrackedPolicy[];
+  isLoadingTrackedPolicies: boolean;
+  isCreatingTrackedPolicy: boolean;
+  removingTrackedPolicyId: string | null;
+  errorMessage: string | null;
+  successMessage: string | null;
+  loadTrackedPolicies: () => Promise<void>;
+  createTrackedPolicy: (sourceUrl: string) => Promise<void>;
+  removeTrackedPolicy: (trackedPolicyId: string) => Promise<void>;
+  clearMessages: () => void;
+}
+
+export function useTrackedPolicies(apiClient: DashboardApiClient): UseTrackedPoliciesResult {
+  const [trackedPolicies, setTrackedPolicies] = useState<DashboardTrackedPolicy[]>([]);
+  const [isLoadingTrackedPolicies, setIsLoadingTrackedPolicies] = useState(false);
+  const [isCreatingTrackedPolicy, setIsCreatingTrackedPolicy] = useState(false);
+  const [removingTrackedPolicyId, setRemovingTrackedPolicyId] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const clearMessages = useCallback(() => {
+    setErrorMessage(null);
+    setSuccessMessage(null);
+  }, []);
+
+  const loadTrackedPolicies = useCallback(async () => {
+    setIsLoadingTrackedPolicies(true);
+    setErrorMessage(null);
+    try {
+      const trackedPoliciesResponse = await apiClient.listTrackedPolicies();
+      setTrackedPolicies(trackedPoliciesResponse.map(mapTrackedPolicy));
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to load your watchlist.');
+    } finally {
+      setIsLoadingTrackedPolicies(false);
+    }
+  }, [apiClient]);
+
+  const createTrackedPolicy = useCallback(
+    async (sourceUrl: string) => {
+      setIsCreatingTrackedPolicy(true);
+      setErrorMessage(null);
+      setSuccessMessage(null);
+      try {
+        const createdTrackedPolicy = await apiClient.createTrackedPolicy({
+          source_url: sourceUrl,
+        });
+        const trackedPoliciesResponse = await apiClient.listTrackedPolicies();
+        setTrackedPolicies(trackedPoliciesResponse.map(mapTrackedPolicy));
+        setSuccessMessage(
+          `${createdTrackedPolicy.display_name} has been added to your watchlist.`,
+        );
+      } catch (error) {
+        setErrorMessage(
+          error instanceof Error ? error.message : 'Failed to add the policy to your watchlist.',
+        );
+      } finally {
+        setIsCreatingTrackedPolicy(false);
+      }
+    },
+    [apiClient],
+  );
+
+  const removeTrackedPolicy = useCallback(
+    async (trackedPolicyId: string) => {
+      setRemovingTrackedPolicyId(trackedPolicyId);
+      setErrorMessage(null);
+      setSuccessMessage(null);
+      try {
+        await apiClient.removeTrackedPolicy(trackedPolicyId);
+        const trackedPoliciesResponse = await apiClient.listTrackedPolicies();
+        setTrackedPolicies(trackedPoliciesResponse.map(mapTrackedPolicy));
+        setSuccessMessage('Policy removed from your watchlist.');
+      } catch (error) {
+        setErrorMessage(
+          error instanceof Error ? error.message : 'Failed to remove the policy from your watchlist.',
+        );
+      } finally {
+        setRemovingTrackedPolicyId(null);
+      }
+    },
+    [apiClient],
+  );
+
+  return {
+    trackedPolicies,
+    isLoadingTrackedPolicies,
+    isCreatingTrackedPolicy,
+    removingTrackedPolicyId,
+    errorMessage,
+    successMessage,
+    loadTrackedPolicies,
+    createTrackedPolicy,
+    removeTrackedPolicy,
+    clearMessages,
+  };
+}

--- a/frontend/src/features/dashboard/mappers.ts
+++ b/frontend/src/features/dashboard/mappers.ts
@@ -5,11 +5,13 @@
 import type {
   ReportListItemResponse,
   ReportResponse,
+  TrackedPolicyResponse,
 } from '../../lib/api/contracts';
 import type {
   DashboardFlaggedClause,
   DashboardReport,
   DashboardReportListItem,
+  DashboardTrackedPolicy,
 } from './types';
 
 function mapFlaggedClause(clause: ReportResponse['flagged_clauses'][number]): DashboardFlaggedClause {
@@ -48,6 +50,18 @@ export function mapReportListItem(response: ReportListItemResponse): DashboardRe
     status: response.status,
     trustScore: response.trust_score,
     modelName: response.model_name,
+    createdAt: response.created_at,
+  };
+}
+
+export function mapTrackedPolicy(response: TrackedPolicyResponse): DashboardTrackedPolicy {
+  return {
+    id: response.id,
+    canonicalUrl: response.canonical_url,
+    displayName: response.display_name,
+    sourceType: response.source_type,
+    trackingStatus: response.tracking_status,
+    lastCheckedAt: response.last_checked_at,
     createdAt: response.created_at,
   };
 }

--- a/frontend/src/features/dashboard/types.ts
+++ b/frontend/src/features/dashboard/types.ts
@@ -39,3 +39,13 @@ export interface DashboardReportListItem {
   modelName: string;
   createdAt: string;
 }
+
+export interface DashboardTrackedPolicy {
+  id: string;
+  canonicalUrl: string;
+  displayName: string;
+  sourceType: string;
+  trackingStatus: string;
+  lastCheckedAt: string | null;
+  createdAt: string;
+}

--- a/frontend/src/features/theme/ThemeProvider.tsx
+++ b/frontend/src/features/theme/ThemeProvider.tsx
@@ -1,0 +1,96 @@
+/* Architecture note:
+ * ThemeProvider is the single app-level owner of persisted color-mode state.
+ * UI surfaces consume `useTheme()` instead of reading localStorage or mutating
+ * document state directly, which keeps the theme seam replaceable and testable.
+ */
+
+import { createContext, type ReactNode, useContext, useEffect, useState } from 'react';
+
+export type ThemeMode = 'dark' | 'light';
+
+interface ThemeContextValue {
+  theme: ThemeMode;
+  toggleTheme: () => void;
+}
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+const DEFAULT_THEME_MODE: ThemeMode = 'dark';
+
+export const THEME_STORAGE_KEY = 'tca.theme.mode';
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [theme, setTheme] = useState<ThemeMode>(() => readStoredThemeMode());
+
+  useEffect(() => {
+    applyDocumentTheme(theme);
+    persistThemeMode(theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider
+      value={{
+        theme,
+        toggleTheme: () => {
+          setTheme((previous) => (previous === 'dark' ? 'light' : 'dark'));
+        },
+      }}
+    >
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider.');
+  }
+  return context;
+}
+
+function readStoredThemeMode(): ThemeMode {
+  const storage = getLocalStorage();
+  if (!storage) {
+    return DEFAULT_THEME_MODE;
+  }
+
+  const storedTheme = storage.getItem(THEME_STORAGE_KEY);
+  return isThemeMode(storedTheme) ? storedTheme : DEFAULT_THEME_MODE;
+}
+
+function persistThemeMode(theme: ThemeMode) {
+  const storage = getLocalStorage();
+  if (!storage) {
+    return;
+  }
+
+  storage.setItem(THEME_STORAGE_KEY, theme);
+}
+
+function applyDocumentTheme(theme: ThemeMode) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  document.documentElement.dataset.theme = theme;
+}
+
+function getLocalStorage(): Storage | null {
+  try {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function isThemeMode(value: string | null): value is ThemeMode {
+  return value === 'dark' || value === 'light';
+}

--- a/frontend/src/features/theme/ThemeToggleButton.tsx
+++ b/frontend/src/features/theme/ThemeToggleButton.tsx
@@ -1,0 +1,43 @@
+import { useTheme } from './ThemeProvider';
+
+export function ThemeToggleButton() {
+  const { theme, toggleTheme } = useTheme();
+  const switchingToLight = theme === 'dark';
+  const label = switchingToLight ? 'Switch to light mode' : 'Switch to dark mode';
+
+  return (
+    <button
+      type="button"
+      className="button-secondary theme-toggle-button"
+      aria-label={label}
+      title={label}
+      onClick={toggleTheme}
+    >
+      {switchingToLight ? <SunIcon /> : <MoonIcon />}
+    </button>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2.75v2.5" />
+      <path d="M12 18.75v2.5" />
+      <path d="M21.25 12h-2.5" />
+      <path d="M5.25 12h-2.5" />
+      <path d="m18.54 5.46-1.77 1.77" />
+      <path d="m7.23 16.77-1.77 1.77" />
+      <path d="m18.54 18.54-1.77-1.77" />
+      <path d="M7.23 7.23 5.46 5.46" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M14.5 3.75a8.75 8.75 0 1 0 5.75 15.35A9.75 9.75 0 0 1 14.5 3.75Z" />
+    </svg>
+  );
+}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -12,6 +12,11 @@ import type {
   ReportListItemResponse,
   ReportResponse,
 } from './contracts';
+import {
+  sanitizeAgreementCreateInput,
+  sanitizeReportAnalyzeInput,
+  validateUuid,
+} from '../security/inputValidation';
 
 export interface DashboardApiClientConfig {
   baseUrl: string;
@@ -51,9 +56,10 @@ export class DashboardApiClient {
   }
 
   async createAgreement(payload: AgreementCreateRequest): Promise<AgreementResponse> {
+    const sanitizedPayload = sanitizeAgreementCreateInput(payload);
     return this.request<AgreementResponse>('/agreements', {
       method: 'POST',
-      body: JSON.stringify(payload),
+      body: JSON.stringify(sanitizedPayload),
     });
   }
 
@@ -61,7 +67,8 @@ export class DashboardApiClient {
     agreementId: string,
     payload: AnalysisTriggerRequest,
   ): Promise<ReportResponse> {
-    return this.request<ReportResponse>(`/agreements/${agreementId}/analyses`, {
+    const normalizedAgreementId = validateUuid(agreementId, 'Agreement id');
+    return this.request<ReportResponse>(`/agreements/${normalizedAgreementId}/analyses`, {
       method: 'POST',
       body: JSON.stringify(payload),
     });
@@ -72,14 +79,15 @@ export class DashboardApiClient {
   }
 
   async submitAndAnalyze(payload: ReportAnalyzeRequest): Promise<ReportResponse> {
+    const sanitizedPayload = sanitizeReportAnalyzeInput(payload);
     return this.request<ReportResponse>('/reports/analyze', {
       method: 'POST',
-      body: JSON.stringify(payload),
+      body: JSON.stringify(sanitizedPayload),
     });
   }
 
   async getReport(reportId: string): Promise<ReportResponse> {
-    return this.request<ReportResponse>(`/reports/${reportId}`);
+    return this.request<ReportResponse>(`/reports/${validateUuid(reportId, 'Report id')}`);
   }
 
   private async request<T>(path: string, init?: RequestInit): Promise<T> {

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -11,10 +11,13 @@ import type {
   ReportAnalyzeRequest,
   ReportListItemResponse,
   ReportResponse,
+  TrackedPolicyCreateRequest,
+  TrackedPolicyResponse,
 } from './contracts';
 import {
   sanitizeAgreementCreateInput,
   sanitizeReportAnalyzeInput,
+  sanitizeTrackedPolicyCreateInput,
   validateUuid,
 } from '../security/inputValidation';
 
@@ -76,6 +79,27 @@ export class DashboardApiClient {
 
   async listReports(): Promise<ReportListItemResponse[]> {
     return this.request<ReportListItemResponse[]>('/reports');
+  }
+
+  async createTrackedPolicy(payload: TrackedPolicyCreateRequest): Promise<TrackedPolicyResponse> {
+    const sanitizedPayload = sanitizeTrackedPolicyCreateInput(payload);
+    return this.request<TrackedPolicyResponse>('/tracked-policies', {
+      method: 'POST',
+      body: JSON.stringify(sanitizedPayload),
+    });
+  }
+
+  async listTrackedPolicies(): Promise<TrackedPolicyResponse[]> {
+    return this.request<TrackedPolicyResponse[]>('/tracked-policies');
+  }
+
+  async removeTrackedPolicy(trackedPolicyId: string): Promise<void> {
+    await this.request<void>(
+      `/tracked-policies/${validateUuid(trackedPolicyId, 'Tracked policy id')}`,
+      {
+        method: 'DELETE',
+      },
+    );
   }
 
   async submitAndAnalyze(payload: ReportAnalyzeRequest): Promise<ReportResponse> {

--- a/frontend/src/lib/api/contracts.ts
+++ b/frontend/src/lib/api/contracts.ts
@@ -18,6 +18,20 @@ export interface AgreementResponse {
   created_at: string;
 }
 
+export interface TrackedPolicyCreateRequest {
+  source_url: string;
+}
+
+export interface TrackedPolicyResponse {
+  id: string;
+  canonical_url: string;
+  display_name: string;
+  source_type: string;
+  tracking_status: string;
+  last_checked_at: string | null;
+  created_at: string;
+}
+
 export interface AnalysisTriggerRequest {
   trigger: 'manual';
 }

--- a/frontend/src/lib/api/createDashboardApiClient.ts
+++ b/frontend/src/lib/api/createDashboardApiClient.ts
@@ -12,6 +12,7 @@ interface CreateDashboardApiClientOptions {
 }
 
 const LOCAL_API_BASE_URL = 'http://127.0.0.1:8000/api/v1';
+const EDGE_PROXY_API_BASE_URL = '/api/v1';
 
 function isLocalHostname(hostname: string): boolean {
   return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
@@ -24,10 +25,15 @@ function resolveDashboardApiBaseUrl(): string {
     return trimmedConfigured;
   }
 
-  if (typeof window !== 'undefined' && !isLocalHostname(window.location.hostname)) {
+  if (typeof window !== 'undefined') {
+    if (isLocalHostname(window.location.hostname)) {
+      return LOCAL_API_BASE_URL;
+    }
+
     console.warn(
-      'VITE_API_BASE_URL is not set. Falling back to the local backend URL. Set VITE_API_BASE_URL in Cloudflare Pages for deployed builds.',
+      'VITE_API_BASE_URL is not set. Falling back to the same-origin Cloudflare edge proxy at /api/v1.',
     );
+    return EDGE_PROXY_API_BASE_URL;
   }
 
   return LOCAL_API_BASE_URL;

--- a/frontend/src/lib/auth/supabaseClient.ts
+++ b/frontend/src/lib/auth/supabaseClient.ts
@@ -23,6 +23,14 @@ import {
   AUTH_PROVIDER_GOOGLE,
   normalizeProviderSignInError,
 } from './providerErrors';
+import {
+  AuthAttemptThrottle,
+  PASSWORD_SIGN_IN_ATTEMPT_POLICY,
+  PASSWORD_SIGN_UP_ATTEMPT_POLICY,
+  createBrowserLocalStorageThrottleStore,
+  normalizeAuthAttemptIdentifier,
+} from '../security/authAttemptThrottle';
+import { sanitizePasswordCredentials } from '../security/inputValidation';
 
 function readEnvValue(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
@@ -83,9 +91,22 @@ class MissingSupabaseConfigurationClient implements AuthClient {
  */
 class SupabaseBrowserAuthClient implements AuthClient {
   private readonly supabaseClient: SupabaseClient;
+  private readonly signInAttemptThrottle: AuthAttemptThrottle;
+  private readonly signUpAttemptThrottle: AuthAttemptThrottle;
 
   constructor(supabaseClient: SupabaseClient) {
     this.supabaseClient = supabaseClient;
+    const throttleStore = createBrowserLocalStorageThrottleStore();
+    this.signInAttemptThrottle = new AuthAttemptThrottle({
+      policy: PASSWORD_SIGN_IN_ATTEMPT_POLICY,
+      store: throttleStore,
+      keyPrefix: 'web_auth_attempts',
+    });
+    this.signUpAttemptThrottle = new AuthAttemptThrottle({
+      policy: PASSWORD_SIGN_UP_ATTEMPT_POLICY,
+      store: throttleStore,
+      keyPrefix: 'web_auth_attempts',
+    });
   }
 
   async getSession(): Promise<AuthenticatedSession | null> {
@@ -112,19 +133,27 @@ class SupabaseBrowserAuthClient implements AuthClient {
   }
 
   async signInWithPassword(credentials: PasswordCredentials): Promise<void> {
+    const normalizedCredentials = sanitizePasswordCredentials(credentials);
+    const normalizedEmail = normalizeAuthAttemptIdentifier(normalizedCredentials.email);
+    await this.signInAttemptThrottle.registerAttempt(normalizedEmail);
     const { error } = await this.supabaseClient.auth.signInWithPassword({
-      email: credentials.email,
-      password: credentials.password,
+      email: normalizedCredentials.email,
+      password: normalizedCredentials.password,
     });
     if (error) {
       throw new Error(error.message);
     }
+    await this.signInAttemptThrottle.clear(normalizedEmail);
   }
 
   async signUpWithPassword(credentials: PasswordCredentials): Promise<void> {
+    const normalizedCredentials = sanitizePasswordCredentials(credentials);
+    await this.signUpAttemptThrottle.registerAttempt(
+      normalizeAuthAttemptIdentifier(normalizedCredentials.email),
+    );
     const { error } = await this.supabaseClient.auth.signUp({
-      email: credentials.email,
-      password: credentials.password,
+      email: normalizedCredentials.email,
+      password: normalizedCredentials.password,
     });
     if (error) {
       throw new Error(error.message);

--- a/frontend/src/lib/security/authAttemptThrottle.ts
+++ b/frontend/src/lib/security/authAttemptThrottle.ts
@@ -1,0 +1,190 @@
+/* Architecture note:
+ * Shared client-side auth throttling for web and extension password flows.
+ * This only protects the shipped clients; backend rate limiting remains the
+ * authoritative server-side control for API abuse.
+ */
+
+export interface AuthAttemptThrottlePolicy {
+  actionKey: string;
+  actionLabel: string;
+  maxAttempts: number;
+  windowMs: number;
+  lockoutMs: number;
+}
+
+export interface AuthAttemptThrottleStore {
+  read: (key: string) => Promise<AuthAttemptThrottleState | null>;
+  write: (key: string, state: AuthAttemptThrottleState) => Promise<void>;
+  remove: (key: string) => Promise<void>;
+}
+
+export interface AuthAttemptThrottleState {
+  attemptTimestamps: number[];
+  blockedUntil: number | null;
+}
+
+export const PASSWORD_SIGN_IN_ATTEMPT_POLICY: AuthAttemptThrottlePolicy = {
+  actionKey: 'password_sign_in',
+  actionLabel: 'sign-in',
+  maxAttempts: 5,
+  windowMs: 10 * 60 * 1000,
+  lockoutMs: 15 * 60 * 1000,
+};
+
+export const PASSWORD_SIGN_UP_ATTEMPT_POLICY: AuthAttemptThrottlePolicy = {
+  actionKey: 'password_sign_up',
+  actionLabel: 'account creation',
+  maxAttempts: 3,
+  windowMs: 30 * 60 * 1000,
+  lockoutMs: 30 * 60 * 1000,
+};
+
+export class AuthAttemptThrottle {
+  private readonly policy: AuthAttemptThrottlePolicy;
+  private readonly store: AuthAttemptThrottleStore;
+  private readonly now: () => number;
+  private readonly keyPrefix: string;
+
+  constructor(options: {
+    policy: AuthAttemptThrottlePolicy;
+    store: AuthAttemptThrottleStore;
+    keyPrefix?: string;
+    now?: () => number;
+  }) {
+    this.policy = options.policy;
+    this.store = options.store;
+    this.now = options.now ?? (() => Date.now());
+    this.keyPrefix = options.keyPrefix ?? 'auth_attempt_throttle';
+  }
+
+  async registerAttempt(identifier: string): Promise<void> {
+    const normalizedIdentifier = normalizeAuthAttemptIdentifier(identifier);
+    const key = this.buildKey(normalizedIdentifier);
+    const state = sanitizeState(await this.store.read(key), this.now(), this.policy.windowMs);
+
+    if (state.blockedUntil && state.blockedUntil > this.now()) {
+      throw new Error(buildBlockedMessage(this.policy.actionLabel, state.blockedUntil - this.now()));
+    }
+
+    if (state.attemptTimestamps.length >= this.policy.maxAttempts) {
+      const blockedUntil = this.now() + this.policy.lockoutMs;
+      await this.store.write(key, {
+        attemptTimestamps: state.attemptTimestamps,
+        blockedUntil,
+      });
+      throw new Error(buildBlockedMessage(this.policy.actionLabel, this.policy.lockoutMs));
+    }
+
+    state.attemptTimestamps.push(this.now());
+    await this.store.write(key, state);
+  }
+
+  async clear(identifier: string): Promise<void> {
+    const normalizedIdentifier = normalizeAuthAttemptIdentifier(identifier);
+    await this.store.remove(this.buildKey(normalizedIdentifier));
+  }
+
+  private buildKey(identifier: string): string {
+    return `${this.keyPrefix}:${this.policy.actionKey}:${identifier}`;
+  }
+}
+
+export function createBrowserLocalStorageThrottleStore(): AuthAttemptThrottleStore {
+  return {
+    async read(key) {
+      const storage = getLocalStorage();
+      if (!storage) {
+        return null;
+      }
+
+      const rawValue = storage.getItem(key);
+      if (!rawValue) {
+        return null;
+      }
+
+      try {
+        const parsed = JSON.parse(rawValue) as AuthAttemptThrottleState;
+        return isThrottleState(parsed) ? parsed : null;
+      } catch {
+        return null;
+      }
+    },
+    async write(key, state) {
+      const storage = getLocalStorage();
+      if (!storage) {
+        return;
+      }
+
+      storage.setItem(key, JSON.stringify(state));
+    },
+    async remove(key) {
+      const storage = getLocalStorage();
+      if (!storage) {
+        return;
+      }
+
+      storage.removeItem(key);
+    },
+  };
+}
+
+export function normalizeAuthAttemptIdentifier(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function sanitizeState(
+  state: AuthAttemptThrottleState | null,
+  now: number,
+  windowMs: number,
+): AuthAttemptThrottleState {
+  const attemptTimestamps = (state?.attemptTimestamps ?? []).filter(
+    (timestamp) => Number.isFinite(timestamp) && now - timestamp < windowMs,
+  );
+  const blockedUntil =
+    state?.blockedUntil && Number.isFinite(state.blockedUntil) && state.blockedUntil > now
+      ? state.blockedUntil
+      : null;
+
+  return {
+    attemptTimestamps,
+    blockedUntil,
+  };
+}
+
+function buildBlockedMessage(actionLabel: string, durationMs: number): string {
+  return `Too many ${actionLabel} attempts. Retry in ${formatDuration(durationMs)}.`;
+}
+
+function formatDuration(durationMs: number): string {
+  const totalSeconds = Math.max(1, Math.ceil(durationMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes > 0 && seconds > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m`;
+  }
+  return `${seconds}s`;
+}
+
+function getLocalStorage(): Storage | null {
+  try {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function isThrottleState(value: unknown): value is AuthAttemptThrottleState {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as AuthAttemptThrottleState;
+  return Array.isArray(candidate.attemptTimestamps);
+}

--- a/frontend/src/lib/security/inputValidation.ts
+++ b/frontend/src/lib/security/inputValidation.ts
@@ -1,0 +1,258 @@
+/* Architecture note:
+ * Shared runtime validation for all user-controlled browser inputs. The backend
+ * still enforces the authoritative rules; these helpers stop obviously invalid
+ * payloads before they hit the network and keep web/extension behavior aligned.
+ */
+
+import type { AgreementCreateRequest, ReportAnalyzeRequest } from '../api/contracts';
+import type { PasswordCredentials } from '../auth/contracts';
+
+export const MAX_TITLE_LENGTH = 200;
+export const MAX_SOURCE_URL_LENGTH = 2048;
+export const MAX_TERMS_TEXT_LENGTH = 200_000;
+export const MIN_TERMS_TEXT_LENGTH = 20;
+export const MAX_EMAIL_LENGTH = 320;
+export const MIN_PASSWORD_LENGTH = 8;
+export const MAX_PASSWORD_LENGTH = 128;
+
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+const UNSAFE_HTML_BLOCK_PATTERN =
+  /<(script|style|iframe|object|embed|svg|noscript)\b[^>]*>[\s\S]*?<\/\1>/gi;
+const HTML_TAG_PATTERN = /<[^>]+>/g;
+const WHITESPACE_PATTERN = /\s+/g;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function sanitizePasswordCredentials(
+  credentials: PasswordCredentials,
+): PasswordCredentials {
+  const email = sanitizeEmailAddress(credentials.email);
+  const password = sanitizePassword(credentials.password);
+  return { email, password };
+}
+
+export function sanitizeReportAnalyzeInput(input: ReportAnalyzeRequest): ReportAnalyzeRequest {
+  const title = sanitizeOptionalSingleLineText(input.title ?? null, {
+    fieldName: 'Title',
+    maxLength: MAX_TITLE_LENGTH,
+  });
+  const sourceUrl = sanitizeOptionalSourceUrl(input.source_url ?? null);
+  const termsText = sanitizeOptionalTermsText(input.terms_text ?? null);
+  const agreedAt = sanitizeOptionalIsoDateTime(input.agreed_at ?? null);
+
+  if (!sourceUrl && !termsText) {
+    throw new Error('Provide either a source URL or terms text.');
+  }
+
+  return {
+    title,
+    source_url: sourceUrl,
+    agreed_at: agreedAt,
+    terms_text: termsText,
+  };
+}
+
+export function sanitizeAgreementCreateInput(
+  input: AgreementCreateRequest,
+): AgreementCreateRequest {
+  return {
+    title: sanitizeOptionalSingleLineText(input.title ?? null, {
+      fieldName: 'Title',
+      maxLength: MAX_TITLE_LENGTH,
+    }),
+    source_url: sanitizeOptionalSourceUrl(input.source_url ?? null),
+    agreed_at: sanitizeOptionalIsoDateTime(input.agreed_at ?? null),
+    terms_text: sanitizeTermsText(input.terms_text),
+  };
+}
+
+export function validateUuid(value: string, fieldName: string): string {
+  const normalized = sanitizeSingleLineText(value, { fieldName, maxLength: 64 }).toLowerCase();
+  if (!UUID_PATTERN.test(normalized)) {
+    throw new Error(`${fieldName} is invalid.`);
+  }
+  return normalized;
+}
+
+export function sanitizeTermsText(value: string): string {
+  const normalized = sanitizeText(value);
+  if (!normalized) {
+    throw new Error('Agreement text cannot be blank.');
+  }
+  if (normalized.length < MIN_TERMS_TEXT_LENGTH) {
+    throw new Error(`Agreement text must be at least ${MIN_TERMS_TEXT_LENGTH} characters.`);
+  }
+  if (normalized.length > MAX_TERMS_TEXT_LENGTH) {
+    throw new Error(`Agreement text must be ${MAX_TERMS_TEXT_LENGTH} characters or fewer.`);
+  }
+  return normalized;
+}
+
+export function sanitizeOptionalTermsText(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  const normalized = sanitizeText(value);
+  if (!normalized) {
+    return null;
+  }
+  return sanitizeTermsText(normalized);
+}
+
+export function sanitizeOptionalSourceUrl(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  const normalized = sanitizeText(value);
+  if (!normalized) {
+    return null;
+  }
+  return validateExternalSourceUrl(normalized);
+}
+
+export function sanitizeOptionalSingleLineText(
+  value: string | null,
+  options: { fieldName: string; maxLength: number },
+): string | null {
+  if (value === null) {
+    return null;
+  }
+  const normalized = sanitizeText(value);
+  if (!normalized) {
+    return null;
+  }
+  return sanitizeSingleLineText(normalized, options);
+}
+
+function sanitizeSingleLineText(
+  value: string,
+  options: { fieldName: string; maxLength: number; minLength?: number },
+): string {
+  const normalized = sanitizeText(value);
+  if (!normalized) {
+    throw new Error(`${options.fieldName} cannot be blank.`);
+  }
+  if (options.minLength && normalized.length < options.minLength) {
+    throw new Error(`${options.fieldName} must be at least ${options.minLength} characters.`);
+  }
+  if (normalized.length > options.maxLength) {
+    throw new Error(`${options.fieldName} must be ${options.maxLength} characters or fewer.`);
+  }
+  return normalized;
+}
+
+function validateExternalSourceUrl(value: string): string {
+  if (value.length > MAX_SOURCE_URL_LENGTH) {
+    throw new Error(`Source URL must be ${MAX_SOURCE_URL_LENGTH} characters or fewer.`);
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('Source URL must be a valid absolute URL.');
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('Source URL must use http or https.');
+  }
+  if (!url.hostname) {
+    throw new Error('Source URL must include a hostname.');
+  }
+  if (url.username || url.password) {
+    throw new Error('Source URL cannot include embedded credentials.');
+  }
+  if (isDisallowedHostname(url.hostname)) {
+    throw new Error('Source URL must target a public hostname.');
+  }
+
+  url.hash = '';
+  return url.toString();
+}
+
+function sanitizeOptionalIsoDateTime(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  const normalized = sanitizeText(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const date = new Date(normalized);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Agreed date is invalid.');
+  }
+  if (date.getTime() > Date.now() + 24 * 60 * 60 * 1000) {
+    throw new Error('Agreed date cannot be in the future.');
+  }
+  return date.toISOString();
+}
+
+function sanitizeEmailAddress(value: string): string {
+  const normalized = sanitizeSingleLineText(value, {
+    fieldName: 'Email',
+    maxLength: MAX_EMAIL_LENGTH,
+  }).toLowerCase();
+
+  if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(normalized)) {
+    throw new Error('Email address is invalid.');
+  }
+  return normalized;
+}
+
+function sanitizePassword(value: string): string {
+  const normalized = value.replace(CONTROL_CHARACTER_PATTERN, '');
+  if (!normalized.trim()) {
+    throw new Error('Password is required.');
+  }
+  if (normalized.length < MIN_PASSWORD_LENGTH) {
+    throw new Error(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+  }
+  if (normalized.length > MAX_PASSWORD_LENGTH) {
+    throw new Error(`Password must be ${MAX_PASSWORD_LENGTH} characters or fewer.`);
+  }
+  return normalized;
+}
+
+function sanitizeText(value: string): string {
+  return value
+    .normalize('NFKC')
+    .replace(CONTROL_CHARACTER_PATTERN, ' ')
+    .replace(UNSAFE_HTML_BLOCK_PATTERN, ' ')
+    .replace(HTML_TAG_PATTERN, ' ')
+    .replace(WHITESPACE_PATTERN, ' ')
+    .trim();
+}
+
+function isDisallowedHostname(hostname: string): boolean {
+  const normalized = hostname.trim().replace(/\.$/, '').toLowerCase();
+  if (!normalized) {
+    return true;
+  }
+  if (normalized === 'localhost' || normalized === '0.0.0.0') {
+    return true;
+  }
+  if (
+    normalized.endsWith('.local') ||
+    normalized.endsWith('.internal') ||
+    normalized.endsWith('.localhost')
+  ) {
+    return true;
+  }
+  if (
+    /^127\./.test(normalized) ||
+    /^10\./.test(normalized) ||
+    /^192\.168\./.test(normalized) ||
+    /^169\.254\./.test(normalized)
+  ) {
+    return true;
+  }
+  if (/^172\.(1[6-9]|2\d|3[0-1])\./.test(normalized)) {
+    return true;
+  }
+  if (normalized === '::1') {
+    return true;
+  }
+  return false;
+}

--- a/frontend/src/lib/security/inputValidation.ts
+++ b/frontend/src/lib/security/inputValidation.ts
@@ -4,7 +4,11 @@
  * payloads before they hit the network and keep web/extension behavior aligned.
  */
 
-import type { AgreementCreateRequest, ReportAnalyzeRequest } from '../api/contracts';
+import type {
+  AgreementCreateRequest,
+  ReportAnalyzeRequest,
+  TrackedPolicyCreateRequest,
+} from '../api/contracts';
 import type { PasswordCredentials } from '../auth/contracts';
 
 export const MAX_TITLE_LENGTH = 200;
@@ -63,6 +67,19 @@ export function sanitizeAgreementCreateInput(
     source_url: sanitizeOptionalSourceUrl(input.source_url ?? null),
     agreed_at: sanitizeOptionalIsoDateTime(input.agreed_at ?? null),
     terms_text: sanitizeTermsText(input.terms_text),
+  };
+}
+
+export function sanitizeTrackedPolicyCreateInput(
+  input: TrackedPolicyCreateRequest,
+): TrackedPolicyCreateRequest {
+  const sourceUrl = sanitizeOptionalSourceUrl(input.source_url);
+  if (!sourceUrl) {
+    throw new Error('Source URL is required.');
+  }
+
+  return {
+    source_url: sourceUrl,
   };
 }
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -134,13 +134,19 @@ textarea:focus {
   box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
+.field-input-limit,
+.field-input-limit:focus {
+  border-color: var(--error-border);
+  box-shadow: 0 0 0 3px rgba(139, 36, 36, 0.12);
+}
+
 textarea {
   min-height: 180px;
   resize: vertical;
 }
 
 .dashboard {
-  max-width: 1260px;
+  max-width: 1360px;
   margin: 0 auto;
   padding: 28px 24px 42px;
   display: grid;
@@ -194,8 +200,8 @@ textarea {
 /* Two-column workbench: control surfaces on the left, analysis output on the right. */
 .dashboard-layout {
   display: grid;
-  grid-template-columns: minmax(340px, 0.98fr) minmax(440px, 1.12fr);
-  gap: 18px;
+  grid-template-columns: minmax(0, 1.34fr) minmax(320px, 0.9fr);
+  gap: 22px;
   align-items: start;
 }
 
@@ -214,6 +220,7 @@ textarea {
 }
 
 .panel {
+  min-width: 0;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
@@ -304,6 +311,25 @@ textarea {
   font-size: 0.82rem;
 }
 
+.terms-support-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.terms-character-counter {
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.terms-character-counter-limit {
+  color: var(--error-text);
+  font-weight: 620;
+}
+
 .actions {
   display: flex;
   align-items: center;
@@ -313,6 +339,11 @@ textarea {
 .submission-actions {
   justify-content: space-between;
   flex-wrap: wrap;
+}
+
+.button-disabled-wrapper {
+  display: inline-flex;
+  max-width: 100%;
 }
 
 .submit-hint {
@@ -475,6 +506,11 @@ textarea {
   list-style: none;
   display: grid;
   gap: 8px;
+  min-width: 0;
+}
+
+.history-list > li {
+  min-width: 0;
 }
 
 .clause-list {
@@ -546,6 +582,7 @@ textarea {
 
 .history-button {
   width: 100%;
+  min-width: 0;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   padding: 10px 11px;
@@ -571,6 +608,7 @@ textarea {
   justify-content: space-between;
   align-items: flex-start;
   gap: 10px;
+  min-width: 0;
 }
 
 .history-primary {
@@ -579,6 +617,7 @@ textarea {
   gap: 8px;
   min-width: 0;
   flex: 1;
+  overflow: hidden;
 }
 
 .history-source-type {
@@ -588,6 +627,8 @@ textarea {
 }
 
 .history-source-value {
+  display: block;
+  flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -600,6 +641,7 @@ textarea {
 }
 
 .history-status-chip {
+  flex-shrink: 0;
   padding: 2px 7px;
   font-size: 0.72rem;
   font-weight: 620;
@@ -714,7 +756,7 @@ textarea {
   width: 100%;
 }
 
-@media (max-width: 1080px) {
+@media (max-width: 1220px) {
   .dashboard-layout {
     grid-template-columns: 1fr;
   }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,4 +1,58 @@
+/* Shared frontend visual tokens. Dark is the current default; light remains as
+ * an explicit opt-in theme so the existing palette is preserved when toggled.
+ */
 :root {
+  --bg: #161b22;
+  --surface: #1d242c;
+  --surface-alt: #242d37;
+  --surface-active: #293749;
+  --text: #edf2f7;
+  --text-muted: #b6c2cf;
+  --text-subtle: #9ba9b9;
+  --border: #354351;
+  --border-strong: #465768;
+  --border-subtle: #293340;
+  --primary: #4f74a8;
+  --primary-hover: #5b82bb;
+  --primary-contrast: #ffffff;
+  --focus: #7ea6df;
+  --focus-ring: rgba(126, 166, 223, 0.24);
+  --input-placeholder: #7d8c9f;
+  --success-bg: #18241f;
+  --success-border: #355845;
+  --success-text: #9acfb0;
+  --error-bg: #28171a;
+  --error-border: #7b464c;
+  --error-text: #efb0b5;
+  --error-ring: rgba(123, 70, 76, 0.24);
+  --tone-positive-border: #3d6651;
+  --tone-positive-bg: #18251e;
+  --tone-positive-text: #98d0ad;
+  --tone-positive-solid: #5aa67a;
+  --tone-caution-border: #7a6632;
+  --tone-caution-bg: #292317;
+  --tone-caution-text: #e0c87c;
+  --tone-caution-solid: #c69735;
+  --tone-danger-border: #7d4b51;
+  --tone-danger-bg: #2b181c;
+  --tone-danger-text: #efadb3;
+  --tone-danger-solid: #d76b74;
+  --tone-neutral-border: #485767;
+  --tone-neutral-bg: #222b35;
+  --tone-neutral-text: #c3ced8;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 10px;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.28);
+  --shadow-md: 0 10px 24px -18px rgba(0, 0, 0, 0.6);
+  font-family: 'Public Sans', 'Noto Sans', 'Liberation Sans', sans-serif;
+  line-height: 1.45;
+  color: var(--text);
+  background: var(--bg);
+  color-scheme: dark;
+}
+
+:root[data-theme='light'] {
   --bg: #e9eef5;
   --surface: #ffffff;
   --surface-alt: #f5f8fc;
@@ -11,23 +65,34 @@
   --border-subtle: #dde6f0;
   --primary: #254f83;
   --primary-hover: #1e426f;
+  --primary-contrast: #ffffff;
   --focus: #3369ad;
   --focus-ring: rgba(51, 105, 173, 0.2);
+  --input-placeholder: #758394;
   --success-bg: #edf8f2;
   --success-border: #badfca;
   --success-text: #214f36;
   --error-bg: #fff1f1;
   --error-border: #efc8c8;
   --error-text: #8b2424;
-  --radius-sm: 6px;
-  --radius-md: 8px;
-  --radius-lg: 10px;
+  --error-ring: rgba(139, 36, 36, 0.12);
+  --tone-positive-border: #b8d6c3;
+  --tone-positive-bg: #e9f7ef;
+  --tone-positive-text: #24533a;
+  --tone-positive-solid: #2f7a53;
+  --tone-caution-border: #e6d8ba;
+  --tone-caution-bg: #fff8e9;
+  --tone-caution-text: #805817;
+  --tone-caution-solid: #a0701f;
+  --tone-danger-border: #e9c1c1;
+  --tone-danger-bg: #fff0f0;
+  --tone-danger-text: #8d2a2a;
+  --tone-danger-solid: #af4141;
+  --tone-neutral-border: #d6d7de;
+  --tone-neutral-bg: #f3f5f8;
+  --tone-neutral-text: #475366;
   --shadow-sm: 0 1px 2px rgba(16, 24, 40, 0.07);
   --shadow-md: 0 2px 8px -6px rgba(16, 24, 40, 0.25);
-  font-family: 'Public Sans', 'Noto Sans', 'Liberation Sans', sans-serif;
-  line-height: 1.45;
-  color: var(--text);
-  background: var(--bg);
   color-scheme: light;
 }
 
@@ -46,6 +111,7 @@ body {
   background: var(--bg);
   color: var(--text);
   -webkit-font-smoothing: antialiased;
+  transition: background-color 140ms ease, color 140ms ease;
 }
 
 input,
@@ -79,7 +145,7 @@ button[disabled] {
 .button-primary {
   border-color: var(--primary);
   background: var(--primary);
-  color: #ffffff;
+  color: var(--primary-contrast);
 }
 
 .button-primary:hover:not([disabled]) {
@@ -91,6 +157,28 @@ button[disabled] {
   border-color: var(--border-strong);
   background: var(--surface);
   color: var(--text);
+}
+
+.theme-toggle-button {
+  width: 40px;
+  min-height: 40px;
+  padding: 0;
+  flex: 0 0 40px;
+  color: var(--text-subtle);
+}
+
+.theme-toggle-button:hover:not([disabled]) {
+  color: var(--text);
+}
+
+.theme-toggle-button svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.85;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .button-link {
@@ -124,7 +212,7 @@ textarea {
 
 input::placeholder,
 textarea::placeholder {
-  color: #758394;
+  color: var(--input-placeholder);
 }
 
 input:focus,
@@ -137,7 +225,7 @@ textarea:focus {
 .field-input-limit,
 .field-input-limit:focus {
   border-color: var(--error-border);
-  box-shadow: 0 0 0 3px rgba(139, 36, 36, 0.12);
+  box-shadow: 0 0 0 3px var(--error-ring);
 }
 
 textarea {
@@ -190,6 +278,8 @@ textarea {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .dashboard-feedback {
@@ -353,6 +443,21 @@ textarea {
   line-height: 1.45;
 }
 
+.watchlist-form {
+  display: grid;
+  gap: 10px;
+}
+
+.watchlist-actions {
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.watchlist-inline-error {
+  margin-top: 10px;
+}
+
 .error-banner,
 .success-banner {
   display: flex;
@@ -435,33 +540,33 @@ textarea {
 }
 
 .score-chip.score-tone-strong {
-  border-color: #b8d6c3;
-  color: #24533a;
-  background: #e9f7ef;
+  border-color: var(--tone-positive-border);
+  color: var(--tone-positive-text);
+  background: var(--tone-positive-bg);
 }
 
 .score-chip.score-tone-moderate {
-  border-color: #e6d8ba;
-  color: #805817;
-  background: #fff8e9;
+  border-color: var(--tone-caution-border);
+  color: var(--tone-caution-text);
+  background: var(--tone-caution-bg);
 }
 
 .score-chip.score-tone-risk {
-  border-color: #e9c1c1;
-  color: #8d2a2a;
-  background: #fff0f0;
+  border-color: var(--tone-danger-border);
+  color: var(--tone-danger-text);
+  background: var(--tone-danger-bg);
 }
 
 .score-meter-fill.score-tone-strong {
-  background: #2f7a53;
+  background: var(--tone-positive-solid);
 }
 
 .score-meter-fill.score-tone-moderate {
-  background: #a0701f;
+  background: var(--tone-caution-solid);
 }
 
 .score-meter-fill.score-tone-risk {
-  background: #af4141;
+  background: var(--tone-danger-solid);
 }
 
 .summary-text {
@@ -518,6 +623,88 @@ textarea {
   margin-top: 10px;
 }
 
+.watchlist-list {
+  margin: 14px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+}
+
+.watchlist-row {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-alt);
+  padding: 12px;
+  display: grid;
+  gap: 10px;
+}
+
+.watchlist-row-main {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.watchlist-row-copy {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.watchlist-display-name {
+  font-size: 0.95rem;
+}
+
+.watchlist-url {
+  min-width: 0;
+  color: var(--text-subtle);
+  font-size: 0.85rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.watchlist-meta {
+  color: var(--text-muted);
+  font-size: 0.81rem;
+}
+
+.watchlist-row-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.watchlist-status-chip {
+  flex-shrink: 0;
+  font-size: 0.72rem;
+  text-transform: capitalize;
+}
+
+.tracking-status-active {
+  border-color: #b7d8c5;
+  color: #25533d;
+  background: #ebf8f1;
+}
+
+.tracking-status-invalid {
+  border-color: #e5c0c0;
+  color: #902b2b;
+  background: #fff2f2;
+}
+
+.tracking-status-pending {
+  border-color: #d6d7de;
+  color: #475366;
+  background: #f3f5f8;
+}
+
+.tracking-status-default {
+  border-color: var(--border);
+  color: var(--text-subtle);
+  background: var(--surface);
+}
+
 .clause-item {
   display: grid;
   gap: 7px;
@@ -545,21 +732,21 @@ textarea {
 }
 
 .severity-high {
-  border-color: #e9c2c2;
-  background: #fff0f0;
-  color: #952525;
+  border-color: var(--tone-danger-border);
+  background: var(--tone-danger-bg);
+  color: var(--tone-danger-text);
 }
 
 .severity-medium {
-  border-color: #e9dbbd;
-  background: #fff9eb;
-  color: #8a5d16;
+  border-color: var(--tone-caution-border);
+  background: var(--tone-caution-bg);
+  color: var(--tone-caution-text);
 }
 
 .severity-low {
-  border-color: #bfddc8;
-  background: #edf8f0;
-  color: #2c6640;
+  border-color: var(--tone-positive-border);
+  background: var(--tone-positive-bg);
+  color: var(--tone-positive-text);
 }
 
 .severity-default {
@@ -650,21 +837,21 @@ textarea {
 }
 
 .history-status-completed {
-  border-color: #b7d8c5;
-  color: #25533d;
-  background: #ebf8f1;
+  border-color: var(--tone-positive-border);
+  color: var(--tone-positive-text);
+  background: var(--tone-positive-bg);
 }
 
 .history-status-failed {
-  border-color: #e5c0c0;
-  color: #902b2b;
-  background: #fff2f2;
+  border-color: var(--tone-danger-border);
+  color: var(--tone-danger-text);
+  background: var(--tone-danger-bg);
 }
 
 .history-status-pending {
-  border-color: #d6d7de;
-  color: #475366;
-  background: #f3f5f8;
+  border-color: var(--tone-neutral-border);
+  color: var(--tone-neutral-text);
+  background: var(--tone-neutral-bg);
 }
 
 .history-status-default {
@@ -768,6 +955,11 @@ textarea {
   }
 
   .history-primary-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .watchlist-row-main {
     flex-direction: column;
     align-items: flex-start;
   }

--- a/frontend/tests/auth.test.tsx
+++ b/frontend/tests/auth.test.tsx
@@ -5,6 +5,7 @@ import type { Mock } from 'vitest';
 
 import { AuthEntryPoint } from '../src/features/auth/AuthEntryPoint';
 import { AuthProvider } from '../src/features/auth/AuthProvider';
+import { THEME_STORAGE_KEY, ThemeProvider } from '../src/features/theme/ThemeProvider';
 import type {
   AuthClient,
   AuthStateChange,
@@ -90,9 +91,11 @@ function createAuthClientHarness(
 
 function renderAuthEntryPoint(harness: AuthClientHarness) {
   return render(
-    <AuthProvider authClient={harness.client}>
-      <AuthEntryPoint />
-    </AuthProvider>,
+    <ThemeProvider>
+      <AuthProvider authClient={harness.client}>
+        <AuthEntryPoint />
+      </AuthProvider>
+    </ThemeProvider>,
   );
 }
 
@@ -101,6 +104,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
   window.localStorage.clear();
+  delete document.documentElement.dataset.theme;
 });
 
 describe('AuthEntryPoint', () => {
@@ -112,6 +116,7 @@ describe('AuthEntryPoint', () => {
     await waitFor(() =>
       expect(screen.getByText('Sign in to Terms and Conditions Analyzer')).toBeTruthy(),
     );
+    await waitFor(() => expect(document.documentElement.dataset.theme).toBe('dark'));
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeTruthy();
   });
 
@@ -193,6 +198,38 @@ describe('AuthEntryPoint', () => {
 
     await waitFor(() => expect(screen.getByText('Terms and Conditions Dashboard')).toBeTruthy());
     expect(screen.getByText('Signed in as auth-user@example.com')).toBeTruthy();
+  });
+
+  it('defaults to dark mode and lets authenticated users toggle the dashboard theme', async () => {
+    const harness = createAuthClientHarness(
+      buildSession({
+        userId: 'themed-user',
+        accessToken: 'themed-session-token',
+        email: 'themed@example.com',
+      }),
+    );
+    const user = userEvent.setup();
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/reports')) {
+        return jsonResponse([]);
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderAuthEntryPoint(harness);
+
+    await waitFor(() => expect(screen.getByText('Terms and Conditions Dashboard')).toBeTruthy());
+    await waitFor(() => expect(document.documentElement.dataset.theme).toBe('dark'));
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+
+    await user.click(screen.getByRole('button', { name: 'Switch to light mode' }));
+
+    await waitFor(() => expect(document.documentElement.dataset.theme).toBe('light'));
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
+    expect(screen.getByRole('button', { name: 'Switch to dark mode' })).toBeTruthy();
   });
 
   it('surfaces denied access errors on the login screen', async () => {

--- a/frontend/tests/dashboard.test.tsx
+++ b/frontend/tests/dashboard.test.tsx
@@ -1,8 +1,9 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { DashboardPage } from '../src/features/dashboard/DashboardPage';
+import { MAX_TERMS_TEXT_LENGTH } from '../src/lib/security/inputValidation';
 import type {
   ReportListItemResponse,
   ReportResponse,
@@ -164,6 +165,32 @@ describe('DashboardPage', () => {
 
     await waitFor(() =>
       expect(screen.getByText('Source URL must target a public hostname.')).toBeTruthy(),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the terms character counter and blocks submission once the UI cap is exceeded', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<DashboardPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText('No reports yet. Submit a terms agreement to create one.')).toBeTruthy(),
+    );
+
+    const termsField = screen.getByLabelText('Terms text');
+    fireEvent.change(termsField, { target: { value: 'x'.repeat(MAX_TERMS_TEXT_LENGTH + 25) } });
+
+    expect(screen.getByText('200,025 / 200,000 characters')).toBeTruthy();
+    expect(
+      screen.getByText("You've exceeded the 200,000 character limit by 25 characters."),
+    ).toBeTruthy();
+    expect(
+      screen.getByTitle("You've exceeded the 200,000 character limit by 25 characters."),
+    ).toBeTruthy();
+    expect((screen.getByRole('button', { name: 'Analyze and save report' }) as HTMLButtonElement).disabled).toBe(
+      true,
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/frontend/tests/dashboard.test.tsx
+++ b/frontend/tests/dashboard.test.tsx
@@ -19,8 +19,8 @@ function jsonResponse(payload: unknown, status = 200): Response {
 
 function buildReport(overrides?: Partial<ReportResponse>): ReportResponse {
   return {
-    id: 'report-1',
-    agreement_id: 'agreement-1',
+    id: '00000000-0000-4000-8000-000000000001',
+    agreement_id: '10000000-0000-4000-8000-000000000001',
     source_type: 'url',
     source_value: 'https://example.com/terms',
     raw_input_excerpt: 'Sample excerpt for testing',
@@ -44,8 +44,8 @@ function buildReport(overrides?: Partial<ReportResponse>): ReportResponse {
 
 function buildListItem(overrides?: Partial<ReportListItemResponse>): ReportListItemResponse {
   return {
-    id: 'report-1',
-    agreement_id: 'agreement-1',
+    id: '00000000-0000-4000-8000-000000000001',
+    agreement_id: '10000000-0000-4000-8000-000000000001',
     source_type: 'url',
     source_value: 'https://example.com/terms',
     status: 'completed',
@@ -144,16 +144,40 @@ describe('DashboardPage', () => {
     );
   });
 
+  it('blocks unsafe source URLs before they are sent to the API', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<DashboardPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText('No reports yet. Submit a terms agreement to create one.')).toBeTruthy(),
+    );
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText('Source URL'), 'http://localhost/private-terms');
+    await user.type(
+      screen.getByLabelText('Terms text'),
+      'These terms include arbitration and automatic renewal clauses.',
+    );
+    await user.click(screen.getByRole('button', { name: 'Analyze and save report' }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Source URL must target a public hostname.')).toBeTruthy(),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('renders saved report history and allows selecting a prior report', async () => {
     const reportOne = buildReport({
-      id: 'report-1',
+      id: '00000000-0000-4000-8000-000000000001',
       summary: 'First summary',
       trust_score: 72,
       source_value: 'https://service-one.example/terms',
       flagged_clauses: [],
     });
     const reportTwo = buildReport({
-      id: 'report-2',
+      id: '00000000-0000-4000-8000-000000000002',
       summary: 'Second summary with risk',
       trust_score: 41,
       source_value: 'https://service-two.example/terms',
@@ -174,21 +198,21 @@ describe('DashboardPage', () => {
       if (url.endsWith('/reports') && method === 'GET') {
         return jsonResponse([
           buildListItem({
-            id: 'report-1',
+            id: '00000000-0000-4000-8000-000000000001',
             source_value: reportOne.source_value,
             trust_score: reportOne.trust_score,
           }),
           buildListItem({
-            id: 'report-2',
+            id: '00000000-0000-4000-8000-000000000002',
             source_value: reportTwo.source_value,
             trust_score: reportTwo.trust_score,
           }),
         ]);
       }
-      if (url.endsWith('/reports/report-2') && method === 'GET') {
+      if (url.endsWith('/reports/00000000-0000-4000-8000-000000000002') && method === 'GET') {
         return jsonResponse(reportTwo);
       }
-      if (url.endsWith('/reports/report-1') && method === 'GET') {
+      if (url.endsWith('/reports/00000000-0000-4000-8000-000000000001') && method === 'GET') {
         return jsonResponse(reportOne);
       }
       throw new Error(`Unexpected request: ${method} ${url}`);
@@ -203,7 +227,9 @@ describe('DashboardPage', () => {
     expect(screen.getByText('https://service-two.example/terms')).toBeTruthy();
 
     const user = userEvent.setup();
-    await user.click(screen.getByRole('button', { name: /URL https:\/\/service-two\.example\/terms/i }));
+    await user.click(
+      screen.getByRole('button', { name: /URL https:\/\/service-two\.example\/terms/i }),
+    );
 
     await waitFor(() => expect(screen.getByText('Trust score: 41 / 100')).toBeTruthy());
     expect(screen.getByText('Second summary with risk')).toBeTruthy();

--- a/frontend/tests/dashboard.test.tsx
+++ b/frontend/tests/dashboard.test.tsx
@@ -7,6 +7,7 @@ import { MAX_TERMS_TEXT_LENGTH } from '../src/lib/security/inputValidation';
 import type {
   ReportListItemResponse,
   ReportResponse,
+  TrackedPolicyResponse,
 } from '../src/lib/api/contracts';
 
 function jsonResponse(payload: unknown, status = 200): Response {
@@ -57,6 +58,19 @@ function buildListItem(overrides?: Partial<ReportListItemResponse>): ReportListI
   };
 }
 
+function buildTrackedPolicy(overrides?: Partial<TrackedPolicyResponse>): TrackedPolicyResponse {
+  return {
+    id: '20000000-0000-4000-8000-000000000001',
+    canonical_url: 'https://example.com/legal/terms',
+    display_name: 'Example Terms',
+    source_type: 'url',
+    tracking_status: 'pending_first_snapshot',
+    last_checked_at: '2026-03-24T15:30:00Z',
+    created_at: '2026-03-24T15:30:00Z',
+    ...overrides,
+  };
+}
+
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
@@ -77,6 +91,9 @@ describe('DashboardPage', () => {
           return jsonResponse([]);
         }
         return jsonResponse([buildListItem()]);
+      }
+      if (url.endsWith('/tracked-policies') && method === 'GET') {
+        return jsonResponse([]);
       }
       if (url.endsWith('/reports/analyze') && method === 'POST') {
         return jsonResponse(report, 201);
@@ -118,6 +135,9 @@ describe('DashboardPage', () => {
       if (url.endsWith('/reports') && method === 'GET') {
         return pending;
       }
+      if (url.endsWith('/tracked-policies') && method === 'GET') {
+        return jsonResponse([]);
+      }
       throw new Error(`Unexpected request: ${method} ${url}`);
     });
     vi.stubGlobal('fetch', fetchMock);
@@ -133,8 +153,17 @@ describe('DashboardPage', () => {
   });
 
   it('shows a user-visible error state when the API request fails', async () => {
-    const fetchMock = vi.fn(async () => {
-      throw new Error('Network error while loading reports');
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+
+      if (url.endsWith('/reports') && method === 'GET') {
+        throw new Error('Network error while loading reports');
+      }
+      if (url.endsWith('/tracked-policies') && method === 'GET') {
+        return jsonResponse([]);
+      }
+      throw new Error(`Unexpected request: ${method} ${url}`);
     });
     vi.stubGlobal('fetch', fetchMock);
 
@@ -166,7 +195,7 @@ describe('DashboardPage', () => {
     await waitFor(() =>
       expect(screen.getByText('Source URL must target a public hostname.')).toBeTruthy(),
     );
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it('shows the terms character counter and blocks submission once the UI cap is exceeded', async () => {
@@ -192,7 +221,7 @@ describe('DashboardPage', () => {
     expect((screen.getByRole('button', { name: 'Analyze and save report' }) as HTMLButtonElement).disabled).toBe(
       true,
     );
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it('renders saved report history and allows selecting a prior report', async () => {
@@ -236,6 +265,9 @@ describe('DashboardPage', () => {
           }),
         ]);
       }
+      if (url.endsWith('/tracked-policies') && method === 'GET') {
+        return jsonResponse([]);
+      }
       if (url.endsWith('/reports/00000000-0000-4000-8000-000000000002') && method === 'GET') {
         return jsonResponse(reportTwo);
       }
@@ -261,5 +293,131 @@ describe('DashboardPage', () => {
     await waitFor(() => expect(screen.getByText('Trust score: 41 / 100')).toBeTruthy());
     expect(screen.getByText('Second summary with risk')).toBeTruthy();
     expect(screen.getByText(/auto renewal/)).toBeTruthy();
+  });
+
+  it('loads the watchlist and lets the user add a tracked policy', async () => {
+    const createdTrackedPolicy = buildTrackedPolicy();
+    let trackedPolicyListCalls = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+
+      if (url.endsWith('/reports') && method === 'GET') {
+        return jsonResponse([]);
+      }
+      if (url.endsWith('/tracked-policies') && method === 'GET') {
+        trackedPolicyListCalls += 1;
+        if (trackedPolicyListCalls === 1) {
+          return jsonResponse([]);
+        }
+        return jsonResponse([createdTrackedPolicy]);
+      }
+      if (url.endsWith('/tracked-policies') && method === 'POST') {
+        return jsonResponse(createdTrackedPolicy, 201);
+      }
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<DashboardPage />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('No tracked policies yet. Add a policy URL to start monitoring changes.'),
+      ).toBeTruthy(),
+    );
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText('Policy URL'), 'https://example.com/legal/terms');
+    await user.click(screen.getByRole('button', { name: 'Add to watchlist' }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Example Terms has been added to your watchlist.')).toBeTruthy(),
+    );
+    expect(screen.getByText('Example Terms')).toBeTruthy();
+    expect(screen.getByText('https://example.com/legal/terms')).toBeTruthy();
+    expect(screen.getByText(/pending first snapshot/i)).toBeTruthy();
+  });
+
+  it('shows an error when adding an invalid tracked-policy URL', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+
+      if (url.endsWith('/reports') && method === 'GET') {
+        return jsonResponse([]);
+      }
+      if (url.endsWith('/tracked-policies') && method === 'GET') {
+        return jsonResponse([]);
+      }
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<DashboardPage />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('No tracked policies yet. Add a policy URL to start monitoring changes.'),
+      ).toBeTruthy(),
+    );
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText('Policy URL'), 'http://localhost/private-terms');
+    await user.click(screen.getByRole('button', { name: 'Add to watchlist' }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Source URL must target a public hostname.')).toBeTruthy(),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('lets the user remove a tracked policy from the watchlist', async () => {
+    const trackedPolicy = buildTrackedPolicy({
+      id: '20000000-0000-4000-8000-000000000002',
+      canonical_url: 'https://service-two.example/legal/terms',
+      display_name: 'Service Two Legal Terms',
+      tracking_status: 'active',
+    });
+    let trackedPolicyListCalls = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+
+      if (url.endsWith('/reports') && method === 'GET') {
+        return jsonResponse([]);
+      }
+      if (url.endsWith('/tracked-policies') && method === 'GET') {
+        trackedPolicyListCalls += 1;
+        if (trackedPolicyListCalls === 1) {
+          return jsonResponse([trackedPolicy]);
+        }
+        return jsonResponse([]);
+      }
+      if (
+        url.endsWith('/tracked-policies/20000000-0000-4000-8000-000000000002') &&
+        method === 'DELETE'
+      ) {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<DashboardPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Service Two Legal Terms')).toBeTruthy(),
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Policy removed from your watchlist.')).toBeTruthy(),
+    );
+    expect(
+      screen.getByText('No tracked policies yet. Add a policy URL to start monitoring changes.'),
+    ).toBeTruthy();
   });
 });

--- a/frontend/tests/edgeWorker.test.ts
+++ b/frontend/tests/edgeWorker.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { proxyApiRequest, resolveBackendOrigin } from '../worker/index';
+
+describe('Cloudflare edge worker proxy', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the configured backend origin when present', () => {
+    const backendOrigin = resolveBackendOrigin(
+      {
+        API_BACKEND_ORIGIN: 'https://terms-api.onrender.com/',
+        ASSETS: { fetch: vi.fn() },
+      },
+      new URL('https://terms.example.workers.dev/api/v1/reports'),
+    );
+
+    expect(backendOrigin).toBe('https://terms-api.onrender.com');
+  });
+
+  it('falls back to the local backend origin for local worker preview', () => {
+    const backendOrigin = resolveBackendOrigin(
+      { ASSETS: { fetch: vi.fn() } },
+      new URL('http://127.0.0.1:8787/api/v1/reports'),
+    );
+
+    expect(backendOrigin).toBe('http://127.0.0.1:8000');
+  });
+
+  it('rejects deployed requests when the backend origin is missing', () => {
+    expect(() =>
+      resolveBackendOrigin(
+        { ASSETS: { fetch: vi.fn() } },
+        new URL('https://terms.example.workers.dev/api/v1/reports'),
+      ),
+    ).toThrow(/API_BACKEND_ORIGIN/);
+  });
+
+  it('forwards API requests through the configured backend origin', async () => {
+    const fetchMock = vi.fn(async (request: Request) => {
+      expect(request.url).toBe('https://terms-api.onrender.com/api/v1/reports');
+      expect(request.headers.get('authorization')).toBe('Bearer test-token');
+      expect(request.headers.get('cf-connecting-ip')).toBe('198.51.100.45');
+      expect(request.headers.get('x-real-ip')).toBe('198.51.100.45');
+      expect(request.headers.get('x-forwarded-host')).toBe('terms.example.workers.dev');
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await proxyApiRequest(
+      new Request('https://terms.example.workers.dev/api/v1/reports', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer test-token',
+          'CF-Connecting-IP': '198.51.100.45',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ terms_text: 'Valid enough terms text for analysis.' }),
+      }),
+      {
+        API_BACKEND_ORIGIN: 'https://terms-api.onrender.com',
+        ASSETS: { fetch: vi.fn() },
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+  });
+
+  it('blocks unsupported methods before they reach the backend', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await proxyApiRequest(
+      new Request('https://terms.example.workers.dev/api/v1/reports', {
+        method: 'DELETE',
+      }),
+      {
+        API_BACKEND_ORIGIN: 'https://terms-api.onrender.com',
+        ASSETS: { fetch: vi.fn() },
+      },
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.status).toBe(405);
+  });
+});

--- a/frontend/tests/supabaseClient.rateLimit.test.ts
+++ b/frontend/tests/supabaseClient.rateLimit.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const signInWithPasswordMock = vi.fn();
+  const signUpMock = vi.fn();
+  const createClientMock = vi.fn(() => ({
+    auth: {
+      getSession: vi.fn(async () => ({ data: { session: null }, error: null })),
+      onAuthStateChange: vi.fn(() => ({
+        data: {
+          subscription: {
+            unsubscribe: vi.fn(),
+          },
+        },
+      })),
+      signInWithPassword: signInWithPasswordMock,
+      signUp: signUpMock,
+      signInWithOAuth: vi.fn(async () => ({ data: null, error: null })),
+      signOut: vi.fn(async () => ({ error: null })),
+    },
+  }));
+
+  return {
+    createClientMock,
+    signInWithPasswordMock,
+    signUpMock,
+  };
+});
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: mocks.createClientMock,
+}));
+
+describe('supabase auth adapter rate limiting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    window.localStorage.clear();
+
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://project-ref.supabase.co');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon-key');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    window.localStorage.clear();
+  });
+
+  it('blocks repeated password sign-in attempts before calling Supabase again', async () => {
+    mocks.signInWithPasswordMock.mockResolvedValue({
+      data: { session: null, user: null },
+      error: { message: 'Invalid login credentials.' },
+    });
+
+    const { getAuthClient } = await import('../src/lib/auth/supabaseClient');
+    const authClient = getAuthClient();
+    const credentials = {
+      email: 'locked-user@example.com',
+      password: 'wrong-password',
+    };
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await expect(authClient.signInWithPassword(credentials)).rejects.toThrow(
+        'Invalid login credentials.',
+      );
+    }
+
+    await expect(authClient.signInWithPassword(credentials)).rejects.toThrow(
+      'Too many sign-in attempts.',
+    );
+    expect(mocks.signInWithPasswordMock).toHaveBeenCalledTimes(5);
+  });
+
+  it('blocks repeated account-creation attempts before calling Supabase again', async () => {
+    mocks.signUpMock.mockResolvedValue({
+      data: { session: null, user: null },
+      error: { message: 'User already registered.' },
+    });
+
+    const { getAuthClient } = await import('../src/lib/auth/supabaseClient');
+    const authClient = getAuthClient();
+    const credentials = {
+      email: 'existing-user@example.com',
+      password: 'strong-password',
+    };
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await expect(authClient.signUpWithPassword(credentials)).rejects.toThrow(
+        'User already registered.',
+      );
+    }
+
+    await expect(authClient.signUpWithPassword(credentials)).rejects.toThrow(
+      'Too many account creation attempts.',
+    );
+    expect(mocks.signUpMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('rejects invalid credentials before calling Supabase', async () => {
+    const { getAuthClient } = await import('../src/lib/auth/supabaseClient');
+    const authClient = getAuthClient();
+
+    await expect(
+      authClient.signInWithPassword({
+        email: 'not-an-email',
+        password: 'short',
+      }),
+    ).rejects.toThrow('Email address is invalid.');
+    await expect(
+      authClient.signUpWithPassword({
+        email: 'valid-user@example.com',
+        password: 'short',
+      }),
+    ).rejects.toThrow('Password must be at least 8 characters.');
+
+    expect(mocks.signInWithPasswordMock).not.toHaveBeenCalled();
+    expect(mocks.signUpMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/theme.test.tsx
+++ b/frontend/tests/theme.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { THEME_STORAGE_KEY, ThemeProvider, useTheme } from '../src/features/theme/ThemeProvider';
+
+function ThemeHarness() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <>
+      <span>{theme}</span>
+      <button type="button" onClick={toggleTheme}>
+        Toggle theme
+      </button>
+    </>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+  delete document.documentElement.dataset.theme;
+});
+
+describe('ThemeProvider', () => {
+  it('defaults to dark mode and applies the document theme when storage is empty', async () => {
+    render(
+      <ThemeProvider>
+        <ThemeHarness />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('dark')).toBeTruthy();
+    await waitFor(() => expect(document.documentElement.dataset.theme).toBe('dark'));
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+  });
+
+  it('restores a saved light preference and persists the next toggle', async () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'light');
+    const user = userEvent.setup();
+
+    render(
+      <ThemeProvider>
+        <ThemeHarness />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('light')).toBeTruthy();
+    await waitFor(() => expect(document.documentElement.dataset.theme).toBe('light'));
+
+    await user.click(screen.getByRole('button', { name: 'Toggle theme' }));
+
+    await waitFor(() => expect(document.documentElement.dataset.theme).toBe('dark'));
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+    expect(screen.getByText('dark')).toBeTruthy();
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,14 +3,24 @@ import react from '@vitejs/plugin-react';
 
 import { cloudflare } from "@cloudflare/vite-plugin";
 
-export default defineConfig({
-  plugins: [react(), cloudflare()],
-  base: '/',
-  build: {
-    outDir: 'dist',
-    emptyOutDir: true,
-  },
-  preview: {
-    port: 4173,
-  },
+export default defineConfig(() => {
+  const plugins = [react()];
+
+  // Vitest runs against browser/jsdom units; it does not need the Cloudflare
+  // worker environment bootstrapped the way deploy/preview builds do.
+  if (!process.env.VITEST) {
+    plugins.push(cloudflare());
+  }
+
+  return {
+    plugins,
+    base: '/',
+    build: {
+      outDir: 'dist',
+      emptyOutDir: true,
+    },
+    preview: {
+      port: 4173,
+    },
+  };
 });

--- a/frontend/worker/index.ts
+++ b/frontend/worker/index.ts
@@ -1,0 +1,144 @@
+/* Architecture note:
+ * Cloudflare owns the edge layer for deployed frontend traffic.
+ *
+ * Responsibilities in this worker:
+ * - proxy `/api/*` requests to the Render-hosted backend so browser API calls
+ *   traverse Cloudflare before reaching the application layer
+ * - preserve forwarding metadata needed for backend rate limiting
+ * - serve the SPA asset bundle for all non-API requests through the ASSETS binding
+ *
+ * Non-responsibilities:
+ * - business validation, auth, and persistence remain in the FastAPI backend
+ * - this worker does not duplicate backend authorization or rate-limit logic
+ */
+
+interface AssetFetcher {
+  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+}
+
+interface WorkerEnv {
+  ASSETS: AssetFetcher;
+  API_BACKEND_ORIGIN?: string;
+}
+
+interface StreamingRequestInit extends RequestInit {
+  duplex?: "half";
+}
+
+const API_PATH_PREFIX = "/api/";
+const LOCAL_BACKEND_ORIGIN = "http://127.0.0.1:8000";
+const ALLOWED_API_METHODS = new Set(["GET", "POST", "OPTIONS"]);
+const PROXY_RESPONSE_HEADERS = {
+  "Cache-Control": "no-store",
+  "X-Content-Type-Options": "nosniff",
+  "X-Robots-Tag": "noindex, nofollow",
+};
+
+export default {
+  async fetch(request: Request, env: WorkerEnv): Promise<Response> {
+    const requestUrl = new URL(request.url);
+    if (requestUrl.pathname.startsWith(API_PATH_PREFIX)) {
+      return proxyApiRequest(request, env, requestUrl);
+    }
+
+    return env.ASSETS.fetch(request);
+  },
+};
+
+export async function proxyApiRequest(
+  request: Request,
+  env: WorkerEnv,
+  requestUrl = new URL(request.url),
+): Promise<Response> {
+  const method = request.method.toUpperCase();
+  if (!ALLOWED_API_METHODS.has(method)) {
+    return jsonResponse(
+      { detail: `Method ${request.method} is not allowed at the edge proxy.` },
+      { status: 405 },
+    );
+  }
+
+  const backendOrigin = resolveBackendOrigin(env, requestUrl);
+  const proxyUrl = new URL(`${requestUrl.pathname}${requestUrl.search}`, backendOrigin);
+  const forwardedHeaders = buildForwardHeaders(request, requestUrl);
+  const requestInit: StreamingRequestInit = {
+    method: request.method,
+    headers: forwardedHeaders,
+    body: method === "GET" || method === "HEAD" ? undefined : request.body,
+    redirect: "manual",
+  };
+
+  if (requestInit.body) {
+    requestInit.duplex = "half";
+  }
+
+  const proxyRequest = new Request(proxyUrl.toString(), requestInit);
+
+  const backendResponse = await fetch(proxyRequest);
+  return withResponseHeaders(backendResponse, PROXY_RESPONSE_HEADERS);
+}
+
+export function resolveBackendOrigin(env: WorkerEnv, requestUrl: URL): string {
+  const configuredOrigin = (env.API_BACKEND_ORIGIN ?? "").trim().replace(/\/+$/, "");
+  if (configuredOrigin) {
+    return configuredOrigin;
+  }
+
+  if (isLocalHostname(requestUrl.hostname)) {
+    return LOCAL_BACKEND_ORIGIN;
+  }
+
+  throw new Error(
+    "Cloudflare Worker API proxy is missing API_BACKEND_ORIGIN. " +
+      "Set it in the Cloudflare Workers dashboard before deploying.",
+  );
+}
+
+function buildForwardHeaders(request: Request, requestUrl: URL): Headers {
+  const headers = new Headers(request.headers);
+  const clientIp = request.headers.get("CF-Connecting-IP")?.trim();
+
+  headers.delete("host");
+  headers.set("X-Forwarded-Host", requestUrl.host);
+  headers.set("X-Forwarded-Proto", requestUrl.protocol.replace(":", ""));
+
+  if (clientIp) {
+    headers.set("CF-Connecting-IP", clientIp);
+    headers.set("X-Real-IP", clientIp);
+
+    const existingForwardedFor = request.headers.get("X-Forwarded-For")?.trim();
+    headers.set(
+      "X-Forwarded-For",
+      existingForwardedFor ? `${existingForwardedFor}, ${clientIp}` : clientIp,
+    );
+  }
+
+  return headers;
+}
+
+function withResponseHeaders(response: Response, extraHeaders: Record<string, string>): Response {
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(extraHeaders)) {
+    headers.set(key, value);
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function jsonResponse(payload: object, init: ResponseInit): Response {
+  return new Response(JSON.stringify(payload), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...PROXY_RESPONSE_HEADERS,
+    },
+  });
+}
+
+function isLocalHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}

--- a/frontend/wrangler.jsonc
+++ b/frontend/wrangler.jsonc
@@ -1,12 +1,15 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "cloud-terms-and-conditions-analyzer",
+  "main": "./worker/index.ts",
   "compatibility_date": "2025-09-27",
   "observability": {
     "enabled": true
   },
   "assets": {
-    "not_found_handling": "single-page-application"
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": ["/api/*"]
   },
   "compatibility_flags": [
     "nodejs_compat"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,12 @@
   "scripts": {
     "lint:frontend": "npm run -w frontend lint",
     "build:frontend": "npm run -w frontend build",
-    "test:frontend": "npm run -w frontend test"
+    "preview:frontend": "npm run -w frontend preview -- --host 127.0.0.1 --port 4173",
+    "test:frontend": "npm run -w frontend test",
+    "typecheck:extension": "npm run --prefix extension typecheck",
+    "test:extension": "npm run --prefix extension test",
+    "build:extension": "npm run --prefix extension build",
+    "verify:docker": "docker compose config"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.57.0",

--- a/render.yaml
+++ b/render.yaml
@@ -54,6 +54,10 @@ services:
         sync: false
       - key: ANALYSIS_GEMINI_BASE_URL
         value: https://generativelanguage.googleapis.com/v1beta
+      - key: ANALYSIS_GEMINI_MAX_INPUT_TOKENS
+        value: "250000"
+      - key: ANALYSIS_GEMINI_ESTIMATED_CHARS_PER_TOKEN
+        value: "3"
       - key: ANALYSIS_OPENAI_COMPATIBLE_API_KEY
         sync: false
       - key: ANALYSIS_OPENAI_COMPATIBLE_MODEL

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -25,6 +25,8 @@ if (-not $SkipNpm) {
     Push-Location $repoRoot
     try {
         npm install
+        Write-Host "Installing extension npm dependencies"
+        npm install --prefix extension --no-audit --no-fund
     }
     finally {
         Pop-Location
@@ -41,3 +43,5 @@ Write-Host "Frontend run command:"
 Write-Host "npm run -w frontend dev -- --host 127.0.0.1 --port 5173"
 Write-Host "Frontend production preview command:"
 Write-Host "npm run -w frontend preview -- --host 127.0.0.1 --port 4173"
+Write-Host "Extension build command:"
+Write-Host "npm run --prefix extension build"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -29,7 +29,12 @@ echo "Installing backend Python dependencies"
 
 if [[ "${SKIP_NPM}" == "false" ]]; then
   echo "Installing frontend/workspace npm dependencies"
-  (cd "${REPO_ROOT}" && npm install)
+  (
+    cd "${REPO_ROOT}"
+    npm install
+    echo "Installing extension npm dependencies"
+    npm install --prefix extension --no-audit --no-fund
+  )
 else
   echo "Skipping npm install"
 fi
@@ -41,3 +46,5 @@ echo "Frontend run command:"
 echo "npm run -w frontend dev -- --host 127.0.0.1 --port 5173"
 echo "Frontend production preview command:"
 echo "npm run -w frontend preview -- --host 127.0.0.1 --port 4173"
+echo "Extension build command:"
+echo "npm run --prefix extension build"

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -1,0 +1,61 @@
+param(
+    [string]$Action = "help",
+    [string]$Target = "all"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+
+function Show-Usage {
+    Write-Host "Usage:"
+    Write-Host "  ./scripts/dev.ps1 run docker"
+    Write-Host "  ./scripts/dev.ps1 run preview"
+    Write-Host "  ./scripts/dev.ps1 rebuild extension"
+    Write-Host "  ./scripts/dev.ps1 rebuild docker"
+}
+
+function Invoke-InRepo([scriptblock]$Command) {
+    Push-Location $repoRoot
+    try {
+        & $Command
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+switch ($Action.ToLowerInvariant()) {
+    "help" {
+        Show-Usage
+    }
+    "run" {
+        switch ($Target.ToLowerInvariant()) {
+            "docker" {
+                Invoke-InRepo { docker compose up }
+            }
+            "preview" {
+                Invoke-InRepo { npm run preview:frontend }
+            }
+            default {
+                throw "Unsupported run target '$Target'. Use docker or preview."
+            }
+        }
+    }
+    "rebuild" {
+        switch ($Target.ToLowerInvariant()) {
+            "extension" {
+                Invoke-InRepo { npm install --prefix extension --no-audit --no-fund }
+            }
+            "docker" {
+                Invoke-InRepo { docker compose build backend frontend }
+            }
+            default {
+                throw "Unsupported rebuild target '$Target'. Use extension or docker."
+            }
+        }
+    }
+    default {
+        throw "Unsupported action '$Action'. Use run, rebuild, or help."
+    }
+}

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${1:-help}"
+TARGET="${2:-all}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+show_usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/dev.sh run docker
+  ./scripts/dev.sh run preview
+  ./scripts/dev.sh rebuild extension
+  ./scripts/dev.sh rebuild docker
+EOF
+}
+
+run_in_repo() {
+  (
+    cd "${REPO_ROOT}"
+    "$@"
+  )
+}
+
+case "${ACTION}" in
+  help)
+    show_usage
+    ;;
+  run)
+    case "${TARGET}" in
+      docker)
+        run_in_repo docker compose up
+        ;;
+      preview)
+        run_in_repo npm run preview:frontend
+        ;;
+      *)
+        echo "Unsupported run target '${TARGET}'. Use: docker or preview." >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  rebuild)
+    case "${TARGET}" in
+      extension)
+        run_in_repo npm install --prefix extension --no-audit --no-fund
+        ;;
+      docker)
+        run_in_repo docker compose build backend frontend
+        ;;
+      *)
+        echo "Unsupported rebuild target '${TARGET}'. Use extension or docker." >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "Unsupported action '${ACTION}'. Use run, rebuild, or help." >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Describe what this PR changes in 2-4 bullets.

- Adds authenticated tracked-policy watchlist support end to end, including backend persistence, API routes, and dashboard UI.
- Introduces a shared public web-source inspection/canonicalization seam so policy URLs are verified before they are saved for tracking.
- Adds dark mode to the dashboard shell and updates shared frontend styling tokens to support theme switching cleanly.


## Linked story / work item

- Closes #6
- Jira / story reference: https://termsandconditionsanalyzer.atlassian.net/browse/SCRUM-15

## Why / What / How

**Why**

- Sprint 2 needs the dashboard to move beyond one-time analysis into ongoing policy tracking.
- The watchlist is the entry point for later snapshot/versioning work and must stay cleanly separated from report-analysis orchestration.
- The branch also includes dashboard polish/follow-up fixes needed to keep the authenticated UI usable in local development.

**What changed**

- Added a new tracked-policy backend slice:
  - `backend/app/services/tracked_policy_service.py`
  - `backend/app/api/routes/tracked_policies.py`
  - `backend/app/schemas/tracked_policies.py`
  - `backend/app/repositories/policy_tracking_status.py`
  - `backend/app/services/web_source.py`
- Extended persistence for tracked policies in:
  - `backend/app/repositories/interfaces.py`
  - `backend/app/repositories/in_memory.py`
  - `backend/app/persistence/postgres.py`
- Added dashboard watchlist client/state/UI in:
  - `frontend/src/lib/api/contracts.ts`
  - `frontend/src/lib/api/client.ts`
  - `frontend/src/features/dashboard/hooks/useTrackedPolicies.ts`
  - `frontend/src/features/dashboard/components/TrackedPolicyWatchlistPanel.tsx`
  - `frontend/src/features/dashboard/DashboardPage.tsx`
- Added dark mode and shell/theme updates in:
  - `frontend/src/features/theme/`
  - `frontend/src/App.tsx`
  - `frontend/src/features/auth/AuthEntryPoint.tsx`
  - `frontend/src/styles/global.css`
- Added/updated test coverage in:
  - `backend/tests/test_tracked_policy_service.py`
  - `backend/tests/test_tracked_policies_api.py`
  - `backend/tests/test_in_memory_repository.py`
  - `frontend/tests/dashboard.test.tsx`
  - `frontend/tests/auth.test.tsx`
  - `frontend/tests/theme.test.tsx`
- Updated local runtime/docs/CORS defaults in:
  - `backend/app/core/config.py`
  - `backend/.env.example`
  - `README.md`
  - `docs/render-cloudflare-deploy.md`

**How**

- The watchlist is implemented as its own domain/service layer rather than adding more responsibility to `AnalysisOrchestrationService`.
- URL registration now canonicalizes the public URL, performs a lightweight fetch, derives a display name from page metadata or hostname, and stores the entry with `pending_first_snapshot`.
- Duplicate protection is enforced at both the service layer and the Postgres persistence layer.
- The dashboard composes a separate `useTrackedPolicies` hook beside the existing report hook so watchlist state stays decoupled from report-analysis state.
- Dark mode is owned by an app-level theme seam rather than leaking theme persistence into dashboard data modules.

## Sprint / estimation

- Sprint: Sprint 2
- Story points: 8

## Changes made

- [x] Frontend
- [x] Backend
- [ ] Extension
- [ ] Infrastructure / DevOps
- [ ] AI / Analysis
- [x] Security / Auth
- [ ] Notifications
- [x] Tests
- [x] Documentation

## Testing

What did you test, and how?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing
- [ ] Not applicable

Verification run:

- `./.venv/Scripts/python.exe -m pytest backend/tests/test_tracked_policy_service.py backend/tests/test_tracked_policies_api.py backend/tests/test_in_memory_repository.py -q`
- `./.venv/Scripts/python.exe -m pytest backend/tests/test_content_ingestion.py backend/tests/test_analysis_service.py backend/tests/test_reports_api_jwt_auth.py backend/tests/test_agreements_api.py backend/tests/test_tracked_policy_service.py backend/tests/test_tracked_policies_api.py backend/tests/test_in_memory_repository.py -q`
- `npm run test:frontend -- dashboard.test.tsx`
- `npm run test:frontend -- auth.test.tsx`
- `npm run build:frontend`

## Reviewer checklist

- [x] PR matches the linked story
- [x] Acceptance criteria are addressed
- [x] Code is understandable and scoped appropriately
- [x] Tests or manual verification are included
- [x] No secrets or sensitive data are committed
- [x] Documentation updated if needed

