### PR TITLE
Refactor/async ready monolith refactor closes #25

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -19,6 +19,7 @@ from ..repositories.in_memory import (
     InMemoryPolicyChangeEventRepository,
     InMemoryPolicySnapshotRepository,
     InMemoryReportRepository,
+    InMemoryTrackedPolicyCheckExecutionRepository,
     InMemoryTrackedPolicyRepository,
     InMemoryStorage,
 )
@@ -50,6 +51,7 @@ def _build_persistence_dependencies():
             PostgresPolicyChangeEventRepository,
             PostgresPolicySnapshotRepository,
             PostgresReportRepository,
+            PostgresTrackedPolicyCheckExecutionRepository,
             PostgresTrackedPolicyRepository,
             PostgresStorage,
         )
@@ -63,10 +65,12 @@ def _build_persistence_dependencies():
         tracked_policy_repository = PostgresTrackedPolicyRepository(storage)
         policy_snapshot_repository = PostgresPolicySnapshotRepository(storage)
         policy_change_event_repository = PostgresPolicyChangeEventRepository(storage)
+        check_execution_repository = PostgresTrackedPolicyCheckExecutionRepository(storage)
         return (
             agreement_repository,
             report_repository,
             tracked_policy_repository,
+            check_execution_repository,
             policy_snapshot_repository,
             policy_change_event_repository,
             storage,
@@ -81,12 +85,14 @@ def _build_persistence_dependencies():
     agreement_repository = InMemoryAgreementRepository(storage)
     report_repository = InMemoryReportRepository(storage)
     tracked_policy_repository = InMemoryTrackedPolicyRepository(storage)
+    check_execution_repository = InMemoryTrackedPolicyCheckExecutionRepository(storage)
     policy_snapshot_repository = InMemoryPolicySnapshotRepository(storage)
     policy_change_event_repository = InMemoryPolicyChangeEventRepository(storage)
     return (
         agreement_repository,
         report_repository,
         tracked_policy_repository,
+        check_execution_repository,
         policy_snapshot_repository,
         policy_change_event_repository,
         storage,
@@ -97,6 +103,7 @@ def _build_persistence_dependencies():
     _agreement_repository,
     _report_repository,
     _tracked_policy_repository,
+    _check_execution_repository,
     _policy_snapshot_repository,
     _policy_change_event_repository,
     _persistence_storage,
@@ -169,6 +176,7 @@ _analysis_service = AnalysisOrchestrationService(
 _tracked_policy_service = TrackedPolicyService(
     tracked_policy_repository=_tracked_policy_repository,
     policy_snapshot_repository=_policy_snapshot_repository,
+    check_execution_repository=_check_execution_repository,
     analysis_service=_analysis_service,
     policy_change_event_repository=_policy_change_event_repository,
     public_web_source_inspector=_public_web_source_inspector,

--- a/backend/app/api/mappers/tracked_policies.py
+++ b/backend/app/api/mappers/tracked_policies.py
@@ -3,10 +3,15 @@
 from ...repositories.models import StoredTrackedPolicy
 from ...schemas.tracked_policies import (
     TrackedPolicyCreateResponse,
+    TrackedPolicyCheckExecutionEnvelope,
+    TrackedPolicyCheckExecutionResponse,
     TrackedPolicyResponse,
     TrackedPolicySnapshotCompareBlockResponse,
     TrackedPolicySnapshotComparisonResponse,
     TrackedPolicySnapshotResponse,
+)
+from ...services.tracked_policy_check_execution_service import (
+    TrackedPolicyCheckExecutionResult,
 )
 from ...services.tracked_policy_service import TrackedPolicyEnrollmentResult
 from ...services.tracked_policy_versions_service import (
@@ -105,4 +110,30 @@ def to_tracked_policy_snapshot_comparison_response(
         comparison_outcome=comparison_result.comparison_outcome,
         normalization_notice=comparison_result.normalization_notice,
         render_mode="split_or_unified",
+    )
+
+
+def to_tracked_policy_check_execution_envelope(
+    execution_result: TrackedPolicyCheckExecutionResult,
+) -> TrackedPolicyCheckExecutionEnvelope:
+    """Map an execution model and resolving policy to the API check-envelope contract."""
+    execution = execution_result.execution
+
+    response_execution = TrackedPolicyCheckExecutionResponse(
+        id=execution.id,
+        tracked_policy_id=execution.tracked_policy_id,
+        status=execution.status.value,
+        result_snapshot_created=execution.result_snapshot_created,
+        failure_message=execution.failure_message,
+        execute_started_at=execution.started_at,
+        execute_finished_at=execution.completed_at,
+    )
+
+    response_tracked_policy = None
+    if execution_result.tracked_policy:
+        response_tracked_policy = to_tracked_policy_response(execution_result.tracked_policy)
+
+    return TrackedPolicyCheckExecutionEnvelope(
+        execution=response_execution,
+        tracked_policy=response_tracked_policy,
     )

--- a/backend/app/api/routes/tracked_policies.py
+++ b/backend/app/api/routes/tracked_policies.py
@@ -115,10 +115,9 @@ def get_tracked_policy_execution(
     """Retrieve the status of a specific tracked-policy check execution."""
 
     try:
-        execution = service._check_execution_service._check_execution_repository.get_by_id(
+        execution = service.get_tracked_policy_execution(
+            subject=subject,
             execution_id=execution_id,
-            subject_type=subject.subject_type,
-            subject_id=subject.subject_id,
         )
     except TrackedPolicyCheckExecutionNotFoundError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error

--- a/backend/app/api/routes/tracked_policies.py
+++ b/backend/app/api/routes/tracked_policies.py
@@ -10,12 +10,15 @@ from ..deps import (
     get_tracked_policy_versions_service,
 )
 from ..mappers.tracked_policies import (
+    to_tracked_policy_check_execution_envelope,
     to_tracked_policy_create_response,
     to_tracked_policy_response,
     to_tracked_policy_snapshot_comparison_response,
     to_tracked_policy_snapshot_response,
 )
 from ...schemas.tracked_policies import (
+    TrackedPolicyCheckExecutionEnvelope,
+    TrackedPolicyCheckExecutionResponse,
     TrackedPolicyCreateRequest,
     TrackedPolicyCreateResponse,
     TrackedPolicyResponse,
@@ -23,11 +26,14 @@ from ...schemas.tracked_policies import (
     TrackedPolicySnapshotResponse,
 )
 from ...services.request_subject import RequestSubject
+from ...services.tracked_policy_check_execution_service import (
+    TrackedPolicyCheckExecutionNotFoundError,
+    TrackedPolicyCheckExecutionResult,
+)
 from ...services.tracked_policy_service import (
     DuplicateTrackedPolicyError,
     InvalidTrackedPolicySourceError,
     TrackedPolicyBaselineReportError,
-    TrackedPolicyCheckFailedError,
     TrackedPolicyNotFoundError,
     TrackedPolicyService,
 )
@@ -81,28 +87,48 @@ def list_tracked_policies(
     return [to_tracked_policy_response(tracked_policy) for tracked_policy in tracked_policies]
 
 
-@router.post("/{tracked_policy_id}/check", response_model=TrackedPolicyResponse)
+@router.post("/{tracked_policy_id}/check", response_model=TrackedPolicyCheckExecutionEnvelope)
 def check_tracked_policy(
     tracked_policy_id: UUID,
     subject: RequestSubject = Depends(get_request_subject),
     service: TrackedPolicyService = Depends(get_tracked_policy_service),
-) -> TrackedPolicyResponse:
+) -> TrackedPolicyCheckExecutionEnvelope:
     """Fetch the live policy page, store a snapshot when text changes, and refresh status."""
 
     try:
-        tracked_policy = service.check_tracked_policy(
+        execution_result = service.check_tracked_policy(
             subject=subject,
             tracked_policy_id=tracked_policy_id,
         )
-    except TrackedPolicyCheckFailedError as error:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=str(error),
-        ) from error
     except TrackedPolicyNotFoundError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
 
-    return to_tracked_policy_response(tracked_policy)
+    return to_tracked_policy_check_execution_envelope(execution_result)
+
+
+@router.get("/executions/{execution_id}", response_model=TrackedPolicyCheckExecutionResponse)
+def get_tracked_policy_execution(
+    execution_id: UUID,
+    subject: RequestSubject = Depends(get_request_subject),
+    service: TrackedPolicyService = Depends(get_tracked_policy_service),
+) -> TrackedPolicyCheckExecutionResponse:
+    """Retrieve the status of a specific tracked-policy check execution."""
+
+    try:
+        execution = service._check_execution_service._check_execution_repository.get_by_id(
+            execution_id=execution_id,
+            subject_type=subject.subject_type,
+            subject_id=subject.subject_id,
+        )
+    except TrackedPolicyCheckExecutionNotFoundError as error:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
+
+    return to_tracked_policy_check_execution_envelope(
+        execution_result=TrackedPolicyCheckExecutionResult(
+            execution=execution,
+            tracked_policy=None,
+        )
+    ).execution
 
 
 @router.get(

--- a/backend/app/persistence/postgres.py
+++ b/backend/app/persistence/postgres.py
@@ -19,7 +19,10 @@ from ..repositories.analysis_status import (
     AnalysisLifecycleStatus,
     normalize_analysis_lifecycle_status,
 )
-from ..repositories.errors import ActiveTrackedPolicyConflictError
+from ..repositories.errors import (
+    ActiveTrackedPolicyCheckExecutionConflictError,
+    ActiveTrackedPolicyConflictError,
+)
 from ..repositories.models import (
     PolicyChangeEventCreateInput,
     PolicySnapshotAppendResult,
@@ -1423,19 +1426,24 @@ class PostgresTrackedPolicyCheckExecutionRepository:
         subject_id: str,
     ) -> StoredTrackedPolicyCheckExecution:
         execution_id = uuid4()
-        with self._storage.connection() as conn:
-            with conn.cursor() as cursor:
-                cursor.execute(
-                    f"""
-                    INSERT INTO tracked_policy_check_executions (
-                      id, tracked_policy_id, subject_type, subject_id, status
-                    ) VALUES (%s, %s, %s, %s, 'pending')
-                    RETURNING {_CHECK_EXECUTION_COLUMNS};
-                    """,
-                    (execution_id, tracked_policy_id, subject_type, subject_id),
-                )
-                row = cursor.fetchone()
-            conn.commit()
+        try:
+            with self._storage.connection() as conn:
+                with conn.cursor() as cursor:
+                    cursor.execute(
+                        f"""
+                        INSERT INTO tracked_policy_check_executions (
+                          id, tracked_policy_id, subject_type, subject_id, status
+                        ) VALUES (%s, %s, %s, %s, 'pending')
+                        RETURNING {_CHECK_EXECUTION_COLUMNS};
+                        """,
+                        (execution_id, tracked_policy_id, subject_type, subject_id),
+                    )
+                    row = cursor.fetchone()
+                conn.commit()
+        except psycopg_errors.UniqueViolation as error:
+            raise ActiveTrackedPolicyCheckExecutionConflictError(
+                "An active tracked-policy check execution already exists for this policy."
+            ) from error
         return _check_execution_from_row(row)
 
     def get_by_id(
@@ -1552,4 +1560,3 @@ class PostgresTrackedPolicyCheckExecutionRepository:
                 row = cursor.fetchone()
             conn.commit()
         return _check_execution_from_row(row) if row else None
-

--- a/backend/app/persistence/postgres.py
+++ b/backend/app/persistence/postgres.py
@@ -30,6 +30,7 @@ from ..repositories.models import (
     StoredFlaggedClause,
     StoredReport,
     StoredTrackedPolicy,
+    StoredTrackedPolicyCheckExecution,
 )
 from ..repositories.policy_capture_status import (
     PolicyCaptureStatus,
@@ -49,6 +50,11 @@ from ..repositories.policy_tracking_status import (
 from ..repositories.report_capture_kind import (
     ReportContentCaptureKind,
     normalize_report_content_capture_kind,
+)
+from ..repositories.tracked_policy_check_execution_status import (
+    TrackedPolicyCheckExecutionStatus,
+    is_active_execution_status,
+    normalize_tracked_policy_check_execution_status,
 )
 
 SCHEMA_SQL = """
@@ -293,6 +299,38 @@ BEGIN
       FOREIGN KEY (new_snapshot_id) REFERENCES policy_snapshots(id) ON DELETE SET NULL;
   END IF;
 END $$;
+
+CREATE TABLE IF NOT EXISTS tracked_policy_check_executions (
+  id UUID PRIMARY KEY,
+  tracked_policy_id UUID NOT NULL REFERENCES tracked_policies(id) ON DELETE CASCADE,
+  subject_type TEXT NOT NULL,
+  subject_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (
+    status IN ('pending', 'running', 'succeeded', 'failed', 'timed_out')
+  ),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  started_at TIMESTAMPTZ NULL,
+  completed_at TIMESTAMPTZ NULL,
+  failure_code TEXT NULL,
+  failure_stage TEXT NULL,
+  failure_message TEXT NULL,
+  failure_retryable BOOLEAN NULL,
+  result_snapshot_created BOOLEAN NULL,
+  result_previous_snapshot_id UUID NULL,
+  result_new_snapshot_id UUID NULL,
+  result_change_event_id UUID NULL
+);
+
+-- Fast active-execution lookup for dedupe: at most one pending/running per policy per owner.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_check_executions_active_dedupe
+  ON tracked_policy_check_executions (tracked_policy_id, subject_type, subject_id)
+  WHERE status IN ('pending', 'running');
+
+CREATE INDEX IF NOT EXISTS idx_check_executions_policy_created
+  ON tracked_policy_check_executions (tracked_policy_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_check_executions_owner_created
+  ON tracked_policy_check_executions (subject_type, subject_id, created_at DESC);
 """
 
 
@@ -361,7 +399,7 @@ class PostgresStorage:
         with self.connection() as conn:
             with conn.cursor() as cursor:
                 cursor.execute(
-                    "TRUNCATE TABLE policy_change_events, policy_snapshots, reports, agreements, tracked_policies;"
+                    "TRUNCATE TABLE tracked_policy_check_executions, policy_change_events, policy_snapshots, reports, agreements, tracked_policies;"
                 )
             conn.commit()
 
@@ -1335,3 +1373,183 @@ def _policy_change_event_from_row(row: dict | None) -> StoredPolicyChangeEvent:
         new_section_count=row.get("new_section_count"),
         section_delta=row.get("section_delta"),
     )
+
+
+_CHECK_EXECUTION_COLUMNS = """
+  id, tracked_policy_id, subject_type, subject_id, status,
+  created_at, started_at, completed_at,
+  failure_code, failure_stage, failure_message, failure_retryable,
+  result_snapshot_created, result_previous_snapshot_id,
+  result_new_snapshot_id, result_change_event_id
+"""
+
+
+def _check_execution_from_row(row: dict | None) -> StoredTrackedPolicyCheckExecution:
+    """Map a DB row dict to ``StoredTrackedPolicyCheckExecution``."""
+
+    if row is None:
+        raise ValueError("Check execution row cannot be None.")
+    return StoredTrackedPolicyCheckExecution(
+        id=row["id"],
+        tracked_policy_id=row["tracked_policy_id"],
+        subject_type=row["subject_type"],
+        subject_id=row["subject_id"],
+        status=normalize_tracked_policy_check_execution_status(row["status"]),
+        created_at=row["created_at"],
+        started_at=row.get("started_at"),
+        completed_at=row.get("completed_at"),
+        failure_code=row.get("failure_code"),
+        failure_stage=row.get("failure_stage"),
+        failure_message=row.get("failure_message"),
+        failure_retryable=row.get("failure_retryable"),
+        result_snapshot_created=row.get("result_snapshot_created"),
+        result_previous_snapshot_id=row.get("result_previous_snapshot_id"),
+        result_new_snapshot_id=row.get("result_new_snapshot_id"),
+        result_change_event_id=row.get("result_change_event_id"),
+    )
+
+
+class PostgresTrackedPolicyCheckExecutionRepository:
+    """Postgres implementation of tracked-policy check execution persistence."""
+
+    def __init__(self, storage: PostgresStorage) -> None:
+        self._storage = storage
+
+    def create(
+        self,
+        *,
+        tracked_policy_id: UUID,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicyCheckExecution:
+        execution_id = uuid4()
+        with self._storage.connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    INSERT INTO tracked_policy_check_executions (
+                      id, tracked_policy_id, subject_type, subject_id, status
+                    ) VALUES (%s, %s, %s, %s, 'pending')
+                    RETURNING {_CHECK_EXECUTION_COLUMNS};
+                    """,
+                    (execution_id, tracked_policy_id, subject_type, subject_id),
+                )
+                row = cursor.fetchone()
+            conn.commit()
+        return _check_execution_from_row(row)
+
+    def get_by_id(
+        self,
+        *,
+        execution_id: UUID,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicyCheckExecution | None:
+        with self._storage.connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    SELECT {_CHECK_EXECUTION_COLUMNS}
+                    FROM tracked_policy_check_executions
+                    WHERE id = %s AND subject_type = %s AND subject_id = %s;
+                    """,
+                    (execution_id, subject_type, subject_id),
+                )
+                row = cursor.fetchone()
+        return _check_execution_from_row(row) if row else None
+
+    def get_active_for_tracked_policy(
+        self,
+        *,
+        tracked_policy_id: UUID,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicyCheckExecution | None:
+        with self._storage.connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    SELECT {_CHECK_EXECUTION_COLUMNS}
+                    FROM tracked_policy_check_executions
+                    WHERE tracked_policy_id = %s
+                      AND subject_type = %s
+                      AND subject_id = %s
+                      AND status IN ('pending', 'running')
+                    ORDER BY created_at DESC
+                    LIMIT 1;
+                    """,
+                    (tracked_policy_id, subject_type, subject_id),
+                )
+                row = cursor.fetchone()
+        return _check_execution_from_row(row) if row else None
+
+    def mark_running(
+        self,
+        *,
+        execution_id: UUID,
+    ) -> StoredTrackedPolicyCheckExecution | None:
+        with self._storage.connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    UPDATE tracked_policy_check_executions
+                    SET status = 'running', started_at = NOW()
+                    WHERE id = %s AND status = 'pending'
+                    RETURNING {_CHECK_EXECUTION_COLUMNS};
+                    """,
+                    (execution_id,),
+                )
+                row = cursor.fetchone()
+            conn.commit()
+        return _check_execution_from_row(row) if row else None
+
+    def mark_completed(
+        self,
+        *,
+        execution_id: UUID,
+        status: TrackedPolicyCheckExecutionStatus,
+        failure_code: str | None = None,
+        failure_stage: str | None = None,
+        failure_message: str | None = None,
+        failure_retryable: bool | None = None,
+        result_snapshot_created: bool | None = None,
+        result_previous_snapshot_id: UUID | None = None,
+        result_new_snapshot_id: UUID | None = None,
+        result_change_event_id: UUID | None = None,
+    ) -> StoredTrackedPolicyCheckExecution | None:
+        with self._storage.connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    UPDATE tracked_policy_check_executions
+                    SET status = %s,
+                        started_at = COALESCE(started_at, NOW()),
+                        completed_at = NOW(),
+                        failure_code = %s,
+                        failure_stage = %s,
+                        failure_message = %s,
+                        failure_retryable = %s,
+                        result_snapshot_created = %s,
+                        result_previous_snapshot_id = %s,
+                        result_new_snapshot_id = %s,
+                        result_change_event_id = %s
+                    WHERE id = %s AND status IN ('pending', 'running')
+                    RETURNING {_CHECK_EXECUTION_COLUMNS};
+                    """,
+                    (
+                        status.value,
+                        failure_code,
+                        failure_stage,
+                        failure_message,
+                        failure_retryable,
+                        result_snapshot_created,
+                        result_previous_snapshot_id,
+                        result_new_snapshot_id,
+                        result_change_event_id,
+                        execution_id,
+                    ),
+                )
+                row = cursor.fetchone()
+            conn.commit()
+        return _check_execution_from_row(row) if row else None
+

--- a/backend/app/repositories/errors.py
+++ b/backend/app/repositories/errors.py
@@ -3,3 +3,7 @@
 
 class ActiveTrackedPolicyConflictError(Exception):
     """Raised when an active tracked policy already exists for the owner/url key."""
+
+
+class ActiveTrackedPolicyCheckExecutionConflictError(Exception):
+    """Raised when an active tracked-policy check execution already exists."""

--- a/backend/app/repositories/in_memory.py
+++ b/backend/app/repositories/in_memory.py
@@ -9,6 +9,7 @@ from dataclasses import replace
 from uuid import UUID, uuid4
 
 from .analysis_status import AnalysisLifecycleStatus, normalize_analysis_lifecycle_status
+from .errors import ActiveTrackedPolicyCheckExecutionConflictError
 from .models import (
     PolicyChangeEventCreateInput,
     PolicySnapshotAppendResult,
@@ -513,6 +514,16 @@ class InMemoryTrackedPolicyCheckExecutionRepository:
         subject_type: str,
         subject_id: str,
     ) -> StoredTrackedPolicyCheckExecution:
+        existing_active_execution = self.get_active_for_tracked_policy(
+            tracked_policy_id=tracked_policy_id,
+            subject_type=subject_type,
+            subject_id=subject_id,
+        )
+        if existing_active_execution is not None:
+            raise ActiveTrackedPolicyCheckExecutionConflictError(
+                "An active tracked-policy check execution already exists for this policy."
+            )
+
         now = datetime.now(timezone.utc)
         execution = StoredTrackedPolicyCheckExecution(
             id=uuid4(),
@@ -620,4 +631,3 @@ class InMemoryTrackedPolicyCheckExecutionRepository:
         )
         self._storage.check_executions[execution_id] = updated
         return updated
-

--- a/backend/app/repositories/in_memory.py
+++ b/backend/app/repositories/in_memory.py
@@ -19,6 +19,7 @@ from .models import (
     StoredPolicySnapshot,
     StoredReport,
     StoredTrackedPolicy,
+    StoredTrackedPolicyCheckExecution,
 )
 from .policy_capture_status import (
     PolicyCaptureStatus,
@@ -33,6 +34,10 @@ from .report_capture_kind import (
     ReportContentCaptureKind,
     normalize_report_content_capture_kind,
 )
+from .tracked_policy_check_execution_status import (
+    TrackedPolicyCheckExecutionStatus,
+    is_active_execution_status,
+)
 
 
 class InMemoryStorage:
@@ -44,6 +49,7 @@ class InMemoryStorage:
         self.tracked_policies: dict[UUID, StoredTrackedPolicy] = {}
         self.policy_snapshots: dict[UUID, list[StoredPolicySnapshot]] = {}
         self.policy_change_events: dict[UUID, list[StoredPolicyChangeEvent]] = {}
+        self.check_executions: dict[UUID, StoredTrackedPolicyCheckExecution] = {}
 
     def clear(self) -> None:
         self.agreements.clear()
@@ -51,6 +57,7 @@ class InMemoryStorage:
         self.tracked_policies.clear()
         self.policy_snapshots.clear()
         self.policy_change_events.clear()
+        self.check_executions.clear()
 
 
 class InMemoryAgreementRepository:
@@ -491,3 +498,126 @@ class InMemoryPolicyChangeEventRepository:
     ) -> list[StoredPolicyChangeEvent]:
         events = self._storage.policy_change_events.get(tracked_policy_id, [])
         return list(reversed(events))
+
+
+class InMemoryTrackedPolicyCheckExecutionRepository:
+    """In-memory implementation of tracked-policy check execution persistence."""
+
+    def __init__(self, storage: InMemoryStorage) -> None:
+        self._storage = storage
+
+    def create(
+        self,
+        *,
+        tracked_policy_id: UUID,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicyCheckExecution:
+        now = datetime.now(timezone.utc)
+        execution = StoredTrackedPolicyCheckExecution(
+            id=uuid4(),
+            tracked_policy_id=tracked_policy_id,
+            subject_type=subject_type,
+            subject_id=subject_id,
+            status=TrackedPolicyCheckExecutionStatus.PENDING,
+            created_at=now,
+            started_at=None,
+            completed_at=None,
+            failure_code=None,
+            failure_stage=None,
+            failure_message=None,
+            failure_retryable=None,
+            result_snapshot_created=None,
+            result_previous_snapshot_id=None,
+            result_new_snapshot_id=None,
+            result_change_event_id=None,
+        )
+        self._storage.check_executions[execution.id] = execution
+        return execution
+
+    def get_by_id(
+        self,
+        *,
+        execution_id: UUID,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicyCheckExecution | None:
+        execution = self._storage.check_executions.get(execution_id)
+        if execution is None:
+            return None
+        if execution.subject_type != subject_type or execution.subject_id != subject_id:
+            return None
+        return execution
+
+    def get_active_for_tracked_policy(
+        self,
+        *,
+        tracked_policy_id: UUID,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicyCheckExecution | None:
+        for execution in self._storage.check_executions.values():
+            if (
+                execution.tracked_policy_id == tracked_policy_id
+                and execution.subject_type == subject_type
+                and execution.subject_id == subject_id
+                and is_active_execution_status(execution.status)
+            ):
+                return execution
+        return None
+
+    def mark_running(
+        self,
+        *,
+        execution_id: UUID,
+    ) -> StoredTrackedPolicyCheckExecution | None:
+        execution = self._storage.check_executions.get(execution_id)
+        if execution is None:
+            return None
+        if execution.status != TrackedPolicyCheckExecutionStatus.PENDING:
+            return None
+        updated = replace(
+            execution,
+            status=TrackedPolicyCheckExecutionStatus.RUNNING,
+            started_at=datetime.now(timezone.utc),
+        )
+        self._storage.check_executions[execution_id] = updated
+        return updated
+
+    def mark_completed(
+        self,
+        *,
+        execution_id: UUID,
+        status: TrackedPolicyCheckExecutionStatus,
+        failure_code: str | None = None,
+        failure_stage: str | None = None,
+        failure_message: str | None = None,
+        failure_retryable: bool | None = None,
+        result_snapshot_created: bool | None = None,
+        result_previous_snapshot_id: UUID | None = None,
+        result_new_snapshot_id: UUID | None = None,
+        result_change_event_id: UUID | None = None,
+    ) -> StoredTrackedPolicyCheckExecution | None:
+        execution = self._storage.check_executions.get(execution_id)
+        if execution is None:
+            return None
+        if not is_active_execution_status(execution.status):
+            return None
+        now = datetime.now(timezone.utc)
+        updated = replace(
+            execution,
+            status=status,
+            started_at=execution.started_at or now,
+            completed_at=now,
+            failure_code=failure_code,
+            failure_stage=failure_stage,
+            failure_message=failure_message,
+            failure_retryable=failure_retryable,
+            result_snapshot_created=result_snapshot_created,
+            result_previous_snapshot_id=result_previous_snapshot_id,
+            result_new_snapshot_id=result_new_snapshot_id,
+            result_change_event_id=result_change_event_id,
+        )
+        self._storage.check_executions[execution_id] = updated
+        return updated
+

--- a/backend/app/repositories/interfaces.py
+++ b/backend/app/repositories/interfaces.py
@@ -20,11 +20,13 @@ from .models import (
     StoredPolicySnapshot,
     StoredReport,
     StoredTrackedPolicy,
+    StoredTrackedPolicyCheckExecution,
 )
 from .policy_capture_status import PolicyCaptureStatus
 from .policy_change_status import PolicyChangeStatus
 from .policy_tracking_status import PolicyTrackingStatus
 from .report_capture_kind import ReportContentCaptureKind
+from .tracked_policy_check_execution_status import TrackedPolicyCheckExecutionStatus
 
 
 class AgreementRepository(Protocol):
@@ -201,3 +203,52 @@ class PolicyChangeEventRepository(Protocol):
         *,
         tracked_policy_id: UUID,
     ) -> list[StoredPolicyChangeEvent]: ...
+
+
+class TrackedPolicyCheckExecutionRepository(Protocol):
+    """Persistence contract for tracked-policy check execution records."""
+
+    def create(
+        self,
+        *,
+        tracked_policy_id: UUID,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicyCheckExecution: ...
+
+    def get_by_id(
+        self,
+        *,
+        execution_id: UUID,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicyCheckExecution | None: ...
+
+    def get_active_for_tracked_policy(
+        self,
+        *,
+        tracked_policy_id: UUID,
+        subject_type: str,
+        subject_id: str,
+    ) -> StoredTrackedPolicyCheckExecution | None: ...
+
+    def mark_running(
+        self,
+        *,
+        execution_id: UUID,
+    ) -> StoredTrackedPolicyCheckExecution | None: ...
+
+    def mark_completed(
+        self,
+        *,
+        execution_id: UUID,
+        status: TrackedPolicyCheckExecutionStatus,
+        failure_code: str | None = None,
+        failure_stage: str | None = None,
+        failure_message: str | None = None,
+        failure_retryable: bool | None = None,
+        result_snapshot_created: bool | None = None,
+        result_previous_snapshot_id: UUID | None = None,
+        result_new_snapshot_id: UUID | None = None,
+        result_change_event_id: UUID | None = None,
+    ) -> StoredTrackedPolicyCheckExecution | None: ...

--- a/backend/app/repositories/models.py
+++ b/backend/app/repositories/models.py
@@ -197,4 +197,3 @@ class StoredTrackedPolicyCheckExecution:
     result_previous_snapshot_id: UUID | None
     result_new_snapshot_id: UUID | None
     result_change_event_id: UUID | None
-

--- a/backend/app/repositories/models.py
+++ b/backend/app/repositories/models.py
@@ -14,6 +14,7 @@ from .policy_capture_status import PolicyCaptureStatus, PolicySnapshotStatus
 from .policy_change_status import PolicyChangeStatus
 from .policy_tracking_status import PolicyTrackingStatus
 from .report_capture_kind import ReportContentCaptureKind
+from .tracked_policy_check_execution_status import TrackedPolicyCheckExecutionStatus
 
 
 @dataclass(frozen=True)
@@ -167,3 +168,33 @@ class StoredPolicyChangeEvent:
     previous_section_count: int | None
     new_section_count: int | None
     section_delta: int | None
+
+
+@dataclass(frozen=True)
+class StoredTrackedPolicyCheckExecution:
+    """Persisted execution record for one tracked-policy check run.
+
+    This model is separate from ``StoredTrackedPolicy`` intentionally: the
+    tracked-policy row captures current watchlist state, while execution
+    records capture individual check-run lifecycle and audit data.
+    """
+
+    id: UUID
+    tracked_policy_id: UUID
+    subject_type: str
+    subject_id: str
+    status: TrackedPolicyCheckExecutionStatus
+    created_at: datetime
+    started_at: datetime | None
+    completed_at: datetime | None
+    # structured failure metadata
+    failure_code: str | None
+    failure_stage: str | None
+    failure_message: str | None
+    failure_retryable: bool | None
+    # result correlation — populated on success
+    result_snapshot_created: bool | None
+    result_previous_snapshot_id: UUID | None
+    result_new_snapshot_id: UUID | None
+    result_change_event_id: UUID | None
+

--- a/backend/app/repositories/tracked_policy_check_execution_status.py
+++ b/backend/app/repositories/tracked_policy_check_execution_status.py
@@ -23,10 +23,12 @@ class TrackedPolicyCheckExecutionStatus(str, Enum):
     TIMED_OUT = "timed_out"
 
 
-_ACTIVE_STATUSES = frozenset({
-    TrackedPolicyCheckExecutionStatus.PENDING,
-    TrackedPolicyCheckExecutionStatus.RUNNING,
-})
+_ACTIVE_STATUSES = frozenset(
+    {
+        TrackedPolicyCheckExecutionStatus.PENDING,
+        TrackedPolicyCheckExecutionStatus.RUNNING,
+    }
+)
 
 
 def is_active_execution_status(status: TrackedPolicyCheckExecutionStatus) -> bool:

--- a/backend/app/repositories/tracked_policy_check_execution_status.py
+++ b/backend/app/repositories/tracked_policy_check_execution_status.py
@@ -1,0 +1,48 @@
+"""Execution-status enum for tracked-policy check runs.
+
+These values describe the lifecycle of one check execution, not the tracked
+policy itself.  The enum is intentionally separate from
+``PolicyTrackingStatus`` so execution history does not pollute watchlist state.
+"""
+
+from enum import Enum
+
+__all__ = [
+    "TrackedPolicyCheckExecutionStatus",
+    "normalize_tracked_policy_check_execution_status",
+]
+
+
+class TrackedPolicyCheckExecutionStatus(str, Enum):
+    """Lifecycle states for one tracked-policy check execution."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    TIMED_OUT = "timed_out"
+
+
+_ACTIVE_STATUSES = frozenset({
+    TrackedPolicyCheckExecutionStatus.PENDING,
+    TrackedPolicyCheckExecutionStatus.RUNNING,
+})
+
+
+def is_active_execution_status(status: TrackedPolicyCheckExecutionStatus) -> bool:
+    """Return True when the status represents an in-progress execution."""
+
+    return status in _ACTIVE_STATUSES
+
+
+def normalize_tracked_policy_check_execution_status(
+    value: TrackedPolicyCheckExecutionStatus | str,
+) -> TrackedPolicyCheckExecutionStatus:
+    """Normalize execution status values, raising for unknown strings."""
+
+    if isinstance(value, TrackedPolicyCheckExecutionStatus):
+        return value
+    try:
+        return TrackedPolicyCheckExecutionStatus(str(value).strip().lower())
+    except ValueError as error:
+        raise ValueError(f"Unsupported check execution status: {value}") from error

--- a/backend/app/schemas/tracked_policies.py
+++ b/backend/app/schemas/tracked_policies.py
@@ -85,3 +85,26 @@ class TrackedPolicySnapshotComparisonResponse(BaseModel):
     comparison_outcome: Literal["meaningful_changes", "no_meaningful_changes"]
     normalization_notice: str | None
     render_mode: Literal["split_or_unified"]
+
+
+class TrackedPolicyCheckExecutionResponse(BaseModel):
+    """Serialized tracked-policy check execution payload."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: UUID
+    tracked_policy_id: UUID
+    status: str
+    result_snapshot_created: bool | None
+    failure_message: str | None
+    execute_started_at: datetime | None
+    execute_finished_at: datetime | None
+
+
+class TrackedPolicyCheckExecutionEnvelope(BaseModel):
+    """Response payload enclosing the execution model and optionally the resulting policy."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    execution: TrackedPolicyCheckExecutionResponse
+    tracked_policy: TrackedPolicyResponse | None

--- a/backend/app/services/tracked_policy_check_execution_service.py
+++ b/backend/app/services/tracked_policy_check_execution_service.py
@@ -1,0 +1,148 @@
+"""Orchestration of tracked-policy check executions.
+
+This service introduces a durable execution model around the existing
+synchronous check logic, adding deduplication and structured failure records.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from ..repositories.interfaces import (
+    TrackedPolicyCheckExecutionRepository,
+    TrackedPolicyRepository,
+)
+from ..repositories.models import (
+    StoredTrackedPolicy,
+    StoredTrackedPolicyCheckExecution,
+)
+from ..repositories.tracked_policy_check_execution_status import TrackedPolicyCheckExecutionStatus
+from .policy_snapshot_service import (
+    PolicySnapshotCheckFailedError,
+    PolicySnapshotService,
+    PolicySnapshotTrackedPolicyNotFoundError,
+)
+from .request_subject import RequestSubject
+
+
+class TrackedPolicyNotFoundError(Exception):
+    """Raised when a tracked policy is not found for the active owner subject."""
+
+
+class TrackedPolicyCheckExecutionNotFoundError(Exception):
+    """Raised when a specific check execution is not found."""
+
+
+@dataclass(frozen=True)
+class TrackedPolicyCheckExecutionResult:
+    """Result of an execution submission or check."""
+
+    execution: StoredTrackedPolicyCheckExecution
+    tracked_policy: StoredTrackedPolicy | None
+
+
+class TrackedPolicyCheckExecutionService:
+    """Coordinate check execution lifecycle and deduplication."""
+
+    def __init__(
+        self,
+        *,
+        tracked_policy_repository: TrackedPolicyRepository,
+        check_execution_repository: TrackedPolicyCheckExecutionRepository,
+        policy_snapshot_service: PolicySnapshotService,
+    ) -> None:
+        self._tracked_policy_repository = tracked_policy_repository
+        self._check_execution_repository = check_execution_repository
+        self._policy_snapshot_service = policy_snapshot_service
+
+    def execute_check(
+        self, *, subject: RequestSubject, tracked_policy_id: UUID
+    ) -> TrackedPolicyCheckExecutionResult:
+        """Submit and synchronously process a tracked-policy check execution."""
+
+        # 1. Ownership Lookup
+        tracked_policy = self._tracked_policy_repository.get_active_for_subject(
+            tracked_policy_id=tracked_policy_id,
+            subject_type=subject.subject_type,
+            subject_id=subject.subject_id,
+        )
+        if tracked_policy is None:
+            raise TrackedPolicyNotFoundError(f"Tracked policy {tracked_policy_id} was not found.")
+
+        # 2. Deduplication
+        active_execution = self._check_execution_repository.get_active_for_tracked_policy(
+            tracked_policy_id=tracked_policy_id,
+            subject_type=subject.subject_type,
+            subject_id=subject.subject_id,
+        )
+        if active_execution is not None:
+            return TrackedPolicyCheckExecutionResult(
+                execution=active_execution,
+                tracked_policy=tracked_policy,
+            )
+
+        # 3. Execution Record Creation
+        execution = self._check_execution_repository.create(
+            tracked_policy_id=tracked_policy_id,
+            subject_type=subject.subject_type,
+            subject_id=subject.subject_id,
+        )
+        self._check_execution_repository.mark_running(execution_id=execution.id)
+
+        # 4. Invocation & State Transitions
+        try:
+            result = self._policy_snapshot_service.check_tracked_policy(
+                subject=subject,
+                tracked_policy_id=tracked_policy_id,
+            )
+            completed_execution = self._check_execution_repository.mark_completed(
+                execution_id=execution.id,
+                status=TrackedPolicyCheckExecutionStatus.SUCCEEDED,
+                result_snapshot_created=result.snapshot_created,
+            )
+            if completed_execution is None:
+                raise ValueError(f"Could not complete execution {execution.id}")
+
+            return TrackedPolicyCheckExecutionResult(
+                execution=completed_execution,
+                tracked_policy=result.tracked_policy,
+            )
+
+        except PolicySnapshotTrackedPolicyNotFoundError as error:
+            _ = self._check_execution_repository.mark_completed(
+                execution_id=execution.id,
+                status=TrackedPolicyCheckExecutionStatus.FAILED,
+                failure_message=str(error),
+                failure_stage="ownership_check",
+            )
+            raise TrackedPolicyNotFoundError(str(error)) from error
+
+        except Exception as error:
+            # 5. Structured failure classification
+            failure_message = str(error)
+            status = TrackedPolicyCheckExecutionStatus.FAILED
+            
+            # Check for timeout semantics in the error message
+            if "timed out" in failure_message.lower() or isinstance(error, TimeoutError):
+                status = TrackedPolicyCheckExecutionStatus.TIMED_OUT
+
+            completed_execution = self._check_execution_repository.mark_completed(
+                execution_id=execution.id,
+                status=status,
+                failure_message=failure_message,
+                failure_stage="capture_and_analysis",
+            )
+            if completed_execution is None:
+                raise ValueError(f"Could not complete execution {execution.id}")
+
+            # Refetch the tracked policy to return the updated error states (like latest_capture_status)
+            updated_tracked_policy = self._tracked_policy_repository.get_active_for_subject(
+                tracked_policy_id=tracked_policy_id,
+                subject_type=subject.subject_type,
+                subject_id=subject.subject_id,
+            )
+            return TrackedPolicyCheckExecutionResult(
+                execution=completed_execution,
+                tracked_policy=updated_tracked_policy,
+            )

--- a/backend/app/services/tracked_policy_check_execution_service.py
+++ b/backend/app/services/tracked_policy_check_execution_service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from uuid import UUID
 
+from ..repositories.errors import ActiveTrackedPolicyCheckExecutionConflictError
 from ..repositories.interfaces import (
     TrackedPolicyCheckExecutionRepository,
     TrackedPolicyRepository,
@@ -83,11 +84,28 @@ class TrackedPolicyCheckExecutionService:
             )
 
         # 3. Execution Record Creation
-        execution = self._check_execution_repository.create(
-            tracked_policy_id=tracked_policy_id,
-            subject_type=subject.subject_type,
-            subject_id=subject.subject_id,
-        )
+        try:
+            execution = self._check_execution_repository.create(
+                tracked_policy_id=tracked_policy_id,
+                subject_type=subject.subject_type,
+                subject_id=subject.subject_id,
+            )
+        except ActiveTrackedPolicyCheckExecutionConflictError:
+            active_execution = self._check_execution_repository.get_active_for_tracked_policy(
+                tracked_policy_id=tracked_policy_id,
+                subject_type=subject.subject_type,
+                subject_id=subject.subject_id,
+            )
+            if active_execution is None:
+                raise RuntimeError(
+                    "Tracked-policy check execution create conflicted, but no active execution "
+                    "could be reloaded."
+                ) from None
+            return TrackedPolicyCheckExecutionResult(
+                execution=active_execution,
+                tracked_policy=tracked_policy,
+            )
+
         self._check_execution_repository.mark_running(execution_id=execution.id)
 
         # 4. Invocation & State Transitions
@@ -122,7 +140,7 @@ class TrackedPolicyCheckExecutionService:
             # 5. Structured failure classification
             failure_message = str(error)
             status = TrackedPolicyCheckExecutionStatus.FAILED
-            
+
             # Check for timeout semantics in the error message
             if "timed out" in failure_message.lower() or isinstance(error, TimeoutError):
                 status = TrackedPolicyCheckExecutionStatus.TIMED_OUT
@@ -146,3 +164,19 @@ class TrackedPolicyCheckExecutionService:
                 execution=completed_execution,
                 tracked_policy=updated_tracked_policy,
             )
+
+    def get_tracked_policy_execution(
+        self, *, subject: RequestSubject, execution_id: UUID
+    ) -> StoredTrackedPolicyCheckExecution:
+        """Return one stored execution scoped to the request subject."""
+
+        execution = self._check_execution_repository.get_by_id(
+            execution_id=execution_id,
+            subject_type=subject.subject_type,
+            subject_id=subject.subject_id,
+        )
+        if execution is None:
+            raise TrackedPolicyCheckExecutionNotFoundError(
+                f"Tracked policy check execution {execution_id} was not found."
+            )
+        return execution

--- a/backend/app/services/tracked_policy_service.py
+++ b/backend/app/services/tracked_policy_service.py
@@ -30,6 +30,7 @@ from ..repositories.models import (
     PolicySnapshotCreateInput,
     StoredReport,
     StoredTrackedPolicy,
+    StoredTrackedPolicyCheckExecution,
 )
 from ..repositories.policy_capture_status import PolicyCaptureStatus
 from ..repositories.policy_change_status import PolicyChangeStatus
@@ -118,10 +119,13 @@ class TrackedPolicyService:
             analysis_service=analysis_service,
             public_web_source_inspector=self._public_web_source_inspector,
         )
-        self._check_execution_service = check_execution_service or TrackedPolicyCheckExecutionService(
-            tracked_policy_repository=tracked_policy_repository,
-            check_execution_repository=check_execution_repository,
-            policy_snapshot_service=self._policy_snapshot_service,
+        self._check_execution_service = (
+            check_execution_service
+            or TrackedPolicyCheckExecutionService(
+                tracked_policy_repository=tracked_policy_repository,
+                check_execution_repository=check_execution_repository,
+                policy_snapshot_service=self._policy_snapshot_service,
+            )
         )
 
     def create_tracked_policy(
@@ -263,8 +267,20 @@ class TrackedPolicyService:
             subject=subject,
             tracked_policy_id=tracked_policy_id,
         )
-        if result.tracked_policy is None and result.execution.status != TrackedPolicyCheckExecutionStatus.PENDING:
+        if (
+            result.tracked_policy is None
+            and result.execution.status != TrackedPolicyCheckExecutionStatus.PENDING
+        ):
             raise TrackedPolicyNotFoundError(f"Tracked policy {tracked_policy_id} was not found.")
-        
+
         return result
 
+    def get_tracked_policy_execution(
+        self, *, subject: RequestSubject, execution_id: UUID
+    ) -> StoredTrackedPolicyCheckExecution:
+        """Return one stored execution for the request subject."""
+
+        return self._check_execution_service.get_tracked_policy_execution(
+            subject=subject,
+            execution_id=execution_id,
+        )

--- a/backend/app/services/tracked_policy_service.py
+++ b/backend/app/services/tracked_policy_service.py
@@ -23,6 +23,7 @@ from ..repositories.errors import ActiveTrackedPolicyConflictError
 from ..repositories.interfaces import (
     PolicyChangeEventRepository,
     PolicySnapshotRepository,
+    TrackedPolicyCheckExecutionRepository,
     TrackedPolicyRepository,
 )
 from ..repositories.models import (
@@ -33,6 +34,7 @@ from ..repositories.models import (
 from ..repositories.policy_capture_status import PolicyCaptureStatus
 from ..repositories.policy_change_status import PolicyChangeStatus
 from ..repositories.policy_tracking_status import PolicyTrackingStatus
+from ..repositories.tracked_policy_check_execution_status import TrackedPolicyCheckExecutionStatus
 from .analysis_service import (
     AgreementNotFoundError,
     AnalysisOrchestrationService,
@@ -46,6 +48,10 @@ from .policy_snapshot_service import (
     PolicySnapshotTrackedPolicyNotFoundError,
 )
 from .request_subject import RequestSubject
+from .tracked_policy_check_execution_service import (
+    TrackedPolicyCheckExecutionResult,
+    TrackedPolicyCheckExecutionService,
+)
 from .web_source import (
     PublicWebSourceInspector,
     WebSourceInspectionError,
@@ -90,10 +96,12 @@ class TrackedPolicyService:
         *,
         tracked_policy_repository: TrackedPolicyRepository,
         policy_snapshot_repository: PolicySnapshotRepository,
+        check_execution_repository: TrackedPolicyCheckExecutionRepository,
         analysis_service: AnalysisOrchestrationService,
         policy_change_event_repository: PolicyChangeEventRepository | None = None,
         public_web_source_inspector: PublicWebSourceInspector | None = None,
         policy_snapshot_service: PolicySnapshotService | None = None,
+        check_execution_service: TrackedPolicyCheckExecutionService | None = None,
         policy_text_canonicalizer: PolicyTextCanonicalizer | None = None,
     ) -> None:
         self._tracked_policy_repository = tracked_policy_repository
@@ -109,6 +117,11 @@ class TrackedPolicyService:
             policy_change_event_repository=policy_change_event_repository,
             analysis_service=analysis_service,
             public_web_source_inspector=self._public_web_source_inspector,
+        )
+        self._check_execution_service = check_execution_service or TrackedPolicyCheckExecutionService(
+            tracked_policy_repository=tracked_policy_repository,
+            check_execution_repository=check_execution_repository,
+            policy_snapshot_service=self._policy_snapshot_service,
         )
 
     def create_tracked_policy(
@@ -240,16 +253,18 @@ class TrackedPolicyService:
 
     def check_tracked_policy(
         self, *, subject: RequestSubject, tracked_policy_id: UUID
-    ) -> StoredTrackedPolicy:
+    ) -> TrackedPolicyCheckExecutionResult:
         """Fetch current policy text, store a new snapshot when it changes, and refresh status."""
 
-        try:
-            result = self._policy_snapshot_service.check_tracked_policy(
-                subject=subject,
-                tracked_policy_id=tracked_policy_id,
-            )
-        except PolicySnapshotTrackedPolicyNotFoundError as error:
-            raise TrackedPolicyNotFoundError(str(error)) from error
-        except PolicySnapshotCheckFailedError as error:
-            raise TrackedPolicyCheckFailedError(str(error)) from error
-        return result.tracked_policy
+        # Note: In future PRs, this synchronously returns an execution object instead of the policy.
+        # For now, we still return the resulting tracked policy to keep the API stable,
+        # but we drive it entirely through the execution deduplication seam.
+        result = self._check_execution_service.execute_check(
+            subject=subject,
+            tracked_policy_id=tracked_policy_id,
+        )
+        if result.tracked_policy is None and result.execution.status != TrackedPolicyCheckExecutionStatus.PENDING:
+            raise TrackedPolicyNotFoundError(f"Tracked policy {tracked_policy_id} was not found.")
+        
+        return result
+

--- a/backend/app/services/tracked_policy_service.py
+++ b/backend/app/services/tracked_policy_service.py
@@ -50,6 +50,7 @@ from .policy_snapshot_service import (
 )
 from .request_subject import RequestSubject
 from .tracked_policy_check_execution_service import (
+    TrackedPolicyNotFoundError as CheckExecutionTrackedPolicyNotFoundError,
     TrackedPolicyCheckExecutionResult,
     TrackedPolicyCheckExecutionService,
 )
@@ -263,10 +264,13 @@ class TrackedPolicyService:
         # Note: In future PRs, this synchronously returns an execution object instead of the policy.
         # For now, we still return the resulting tracked policy to keep the API stable,
         # but we drive it entirely through the execution deduplication seam.
-        result = self._check_execution_service.execute_check(
-            subject=subject,
-            tracked_policy_id=tracked_policy_id,
-        )
+        try:
+            result = self._check_execution_service.execute_check(
+                subject=subject,
+                tracked_policy_id=tracked_policy_id,
+            )
+        except CheckExecutionTrackedPolicyNotFoundError as error:
+            raise TrackedPolicyNotFoundError(str(error)) from error
         if (
             result.tracked_policy is None
             and result.execution.status != TrackedPolicyCheckExecutionStatus.PENDING

--- a/backend/tests/test_check_execution_repository.py
+++ b/backend/tests/test_check_execution_repository.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 
 import pytest
 
+from app.repositories.errors import ActiveTrackedPolicyCheckExecutionConflictError
 from app.repositories.in_memory import (
     InMemoryTrackedPolicyCheckExecutionRepository,
     InMemoryStorage,
@@ -72,6 +73,32 @@ def test_create_returns_pending_execution_with_timestamps() -> None:
     assert execution.result_snapshot_created is None
 
 
+def test_create_rejects_duplicate_active_execution_for_same_owner_and_policy() -> None:
+    repo = _build_repo()
+    repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+
+    with pytest.raises(
+        ActiveTrackedPolicyCheckExecutionConflictError,
+        match="active tracked-policy check execution",
+    ):
+        repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+
+
+def test_create_succeeds_after_prior_execution_reaches_terminal_state() -> None:
+    repo = _build_repo()
+    first_execution = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+    repo.mark_running(execution_id=first_execution.id)
+    repo.mark_completed(
+        execution_id=first_execution.id,
+        status=TrackedPolicyCheckExecutionStatus.SUCCEEDED,
+    )
+
+    second_execution = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+
+    assert second_execution.id != first_execution.id
+    assert second_execution.status == TrackedPolicyCheckExecutionStatus.PENDING
+
+
 def test_get_by_id_returns_execution_for_owner() -> None:
     repo = _build_repo()
     created = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
@@ -99,9 +126,7 @@ def test_get_by_id_returns_none_for_unknown_id() -> None:
 def test_get_active_returns_pending_execution() -> None:
     repo = _build_repo()
     created = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
-    active = repo.get_active_for_tracked_policy(
-        tracked_policy_id=TRACKED_POLICY_ID, **OWNER
-    )
+    active = repo.get_active_for_tracked_policy(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
 
     assert active is not None
     assert active.id == created.id
@@ -111,9 +136,7 @@ def test_get_active_returns_running_execution() -> None:
     repo = _build_repo()
     created = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
     repo.mark_running(execution_id=created.id)
-    active = repo.get_active_for_tracked_policy(
-        tracked_policy_id=TRACKED_POLICY_ID, **OWNER
-    )
+    active = repo.get_active_for_tracked_policy(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
 
     assert active is not None
     assert active.status == TrackedPolicyCheckExecutionStatus.RUNNING
@@ -128,9 +151,7 @@ def test_get_active_returns_none_after_completion() -> None:
         status=TrackedPolicyCheckExecutionStatus.SUCCEEDED,
         result_snapshot_created=True,
     )
-    active = repo.get_active_for_tracked_policy(
-        tracked_policy_id=TRACKED_POLICY_ID, **OWNER
-    )
+    active = repo.get_active_for_tracked_policy(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
 
     assert active is None
 
@@ -138,9 +159,7 @@ def test_get_active_returns_none_after_completion() -> None:
 def test_get_active_scopes_to_owner() -> None:
     repo = _build_repo()
     repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
-    active = repo.get_active_for_tracked_policy(
-        tracked_policy_id=TRACKED_POLICY_ID, **OTHER_OWNER
-    )
+    active = repo.get_active_for_tracked_policy(tracked_policy_id=TRACKED_POLICY_ID, **OTHER_OWNER)
 
     assert active is None
 
@@ -249,6 +268,4 @@ def test_storage_clear_removes_check_executions() -> None:
     repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
     storage.clear()
 
-    assert repo.get_active_for_tracked_policy(
-        tracked_policy_id=TRACKED_POLICY_ID, **OWNER
-    ) is None
+    assert repo.get_active_for_tracked_policy(tracked_policy_id=TRACKED_POLICY_ID, **OWNER) is None

--- a/backend/tests/test_check_execution_repository.py
+++ b/backend/tests/test_check_execution_repository.py
@@ -1,0 +1,254 @@
+from uuid import uuid4
+
+import pytest
+
+from app.repositories.in_memory import (
+    InMemoryTrackedPolicyCheckExecutionRepository,
+    InMemoryStorage,
+)
+from app.repositories.tracked_policy_check_execution_status import (
+    TrackedPolicyCheckExecutionStatus,
+    is_active_execution_status,
+    normalize_tracked_policy_check_execution_status,
+)
+
+
+def test_execution_status_enum_has_required_values() -> None:
+    assert TrackedPolicyCheckExecutionStatus.PENDING.value == "pending"
+    assert TrackedPolicyCheckExecutionStatus.RUNNING.value == "running"
+    assert TrackedPolicyCheckExecutionStatus.SUCCEEDED.value == "succeeded"
+    assert TrackedPolicyCheckExecutionStatus.FAILED.value == "failed"
+    assert TrackedPolicyCheckExecutionStatus.TIMED_OUT.value == "timed_out"
+
+
+def test_active_status_helper_identifies_active_and_terminal_states() -> None:
+    assert is_active_execution_status(TrackedPolicyCheckExecutionStatus.PENDING) is True
+    assert is_active_execution_status(TrackedPolicyCheckExecutionStatus.RUNNING) is True
+    assert is_active_execution_status(TrackedPolicyCheckExecutionStatus.SUCCEEDED) is False
+    assert is_active_execution_status(TrackedPolicyCheckExecutionStatus.FAILED) is False
+    assert is_active_execution_status(TrackedPolicyCheckExecutionStatus.TIMED_OUT) is False
+
+
+def test_normalize_execution_status_accepts_string_and_enum() -> None:
+    assert (
+        normalize_tracked_policy_check_execution_status("pending")
+        == TrackedPolicyCheckExecutionStatus.PENDING
+    )
+    assert (
+        normalize_tracked_policy_check_execution_status(TrackedPolicyCheckExecutionStatus.FAILED)
+        == TrackedPolicyCheckExecutionStatus.FAILED
+    )
+
+
+def test_normalize_execution_status_rejects_unknown_value() -> None:
+    with pytest.raises(ValueError, match="Unsupported check execution status"):
+        normalize_tracked_policy_check_execution_status("bogus")
+
+
+# ── In-memory repository contract tests ──────────────────────────────────
+
+
+def _build_repo() -> InMemoryTrackedPolicyCheckExecutionRepository:
+    return InMemoryTrackedPolicyCheckExecutionRepository(InMemoryStorage())
+
+
+TRACKED_POLICY_ID = uuid4()
+OWNER = {"subject_type": "supabase_user", "subject_id": "user-a"}
+OTHER_OWNER = {"subject_type": "supabase_user", "subject_id": "user-b"}
+
+
+def test_create_returns_pending_execution_with_timestamps() -> None:
+    repo = _build_repo()
+    execution = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+
+    assert execution.status == TrackedPolicyCheckExecutionStatus.PENDING
+    assert execution.tracked_policy_id == TRACKED_POLICY_ID
+    assert execution.subject_type == OWNER["subject_type"]
+    assert execution.subject_id == OWNER["subject_id"]
+    assert execution.created_at is not None
+    assert execution.started_at is None
+    assert execution.completed_at is None
+    assert execution.failure_code is None
+    assert execution.result_snapshot_created is None
+
+
+def test_get_by_id_returns_execution_for_owner() -> None:
+    repo = _build_repo()
+    created = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+    fetched = repo.get_by_id(execution_id=created.id, **OWNER)
+
+    assert fetched is not None
+    assert fetched.id == created.id
+
+
+def test_get_by_id_returns_none_for_different_owner() -> None:
+    repo = _build_repo()
+    created = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+    fetched = repo.get_by_id(execution_id=created.id, **OTHER_OWNER)
+
+    assert fetched is None
+
+
+def test_get_by_id_returns_none_for_unknown_id() -> None:
+    repo = _build_repo()
+    fetched = repo.get_by_id(execution_id=uuid4(), **OWNER)
+
+    assert fetched is None
+
+
+def test_get_active_returns_pending_execution() -> None:
+    repo = _build_repo()
+    created = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+    active = repo.get_active_for_tracked_policy(
+        tracked_policy_id=TRACKED_POLICY_ID, **OWNER
+    )
+
+    assert active is not None
+    assert active.id == created.id
+
+
+def test_get_active_returns_running_execution() -> None:
+    repo = _build_repo()
+    created = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+    repo.mark_running(execution_id=created.id)
+    active = repo.get_active_for_tracked_policy(
+        tracked_policy_id=TRACKED_POLICY_ID, **OWNER
+    )
+
+    assert active is not None
+    assert active.status == TrackedPolicyCheckExecutionStatus.RUNNING
+
+
+def test_get_active_returns_none_after_completion() -> None:
+    repo = _build_repo()
+    created = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+    repo.mark_running(execution_id=created.id)
+    repo.mark_completed(
+        execution_id=created.id,
+        status=TrackedPolicyCheckExecutionStatus.SUCCEEDED,
+        result_snapshot_created=True,
+    )
+    active = repo.get_active_for_tracked_policy(
+        tracked_policy_id=TRACKED_POLICY_ID, **OWNER
+    )
+
+    assert active is None
+
+
+def test_get_active_scopes_to_owner() -> None:
+    repo = _build_repo()
+    repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+    active = repo.get_active_for_tracked_policy(
+        tracked_policy_id=TRACKED_POLICY_ID, **OTHER_OWNER
+    )
+
+    assert active is None
+
+
+def test_mark_running_transitions_pending_to_running_with_started_at() -> None:
+    repo = _build_repo()
+    created = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+    running = repo.mark_running(execution_id=created.id)
+
+    assert running is not None
+    assert running.status == TrackedPolicyCheckExecutionStatus.RUNNING
+    assert running.started_at is not None
+
+
+def test_mark_running_rejects_non_pending_execution() -> None:
+    repo = _build_repo()
+    created = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+    repo.mark_running(execution_id=created.id)
+    second_attempt = repo.mark_running(execution_id=created.id)
+
+    assert second_attempt is None
+
+
+def test_mark_completed_with_success_sets_terminal_fields() -> None:
+    repo = _build_repo()
+    created = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+    repo.mark_running(execution_id=created.id)
+    snapshot_id = uuid4()
+    change_event_id = uuid4()
+    completed = repo.mark_completed(
+        execution_id=created.id,
+        status=TrackedPolicyCheckExecutionStatus.SUCCEEDED,
+        result_snapshot_created=True,
+        result_new_snapshot_id=snapshot_id,
+        result_change_event_id=change_event_id,
+    )
+
+    assert completed is not None
+    assert completed.status == TrackedPolicyCheckExecutionStatus.SUCCEEDED
+    assert completed.completed_at is not None
+    assert completed.result_snapshot_created is True
+    assert completed.result_new_snapshot_id == snapshot_id
+    assert completed.result_change_event_id == change_event_id
+    assert completed.failure_code is None
+
+
+def test_mark_completed_with_failure_records_structured_metadata() -> None:
+    repo = _build_repo()
+    created = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+    repo.mark_running(execution_id=created.id)
+    failed = repo.mark_completed(
+        execution_id=created.id,
+        status=TrackedPolicyCheckExecutionStatus.FAILED,
+        failure_code="capture_failed",
+        failure_stage="fetch",
+        failure_message="403 Forbidden",
+        failure_retryable=True,
+    )
+
+    assert failed is not None
+    assert failed.status == TrackedPolicyCheckExecutionStatus.FAILED
+    assert failed.failure_code == "capture_failed"
+    assert failed.failure_stage == "fetch"
+    assert failed.failure_message == "403 Forbidden"
+    assert failed.failure_retryable is True
+    assert failed.result_snapshot_created is None
+
+
+def test_mark_completed_rejects_already_terminal_execution() -> None:
+    repo = _build_repo()
+    created = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+    repo.mark_running(execution_id=created.id)
+    repo.mark_completed(
+        execution_id=created.id,
+        status=TrackedPolicyCheckExecutionStatus.SUCCEEDED,
+    )
+    second = repo.mark_completed(
+        execution_id=created.id,
+        status=TrackedPolicyCheckExecutionStatus.FAILED,
+        failure_code="late_failure",
+    )
+
+    assert second is None
+
+
+def test_mark_completed_can_transition_directly_from_pending() -> None:
+    """A pending execution can be marked completed without going through running."""
+    repo = _build_repo()
+    created = repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+    completed = repo.mark_completed(
+        execution_id=created.id,
+        status=TrackedPolicyCheckExecutionStatus.FAILED,
+        failure_code="validation_error",
+        failure_message="Tracked policy not found",
+    )
+
+    assert completed is not None
+    assert completed.status == TrackedPolicyCheckExecutionStatus.FAILED
+    assert completed.started_at is not None  # backfilled
+    assert completed.completed_at is not None
+
+
+def test_storage_clear_removes_check_executions() -> None:
+    storage = InMemoryStorage()
+    repo = InMemoryTrackedPolicyCheckExecutionRepository(storage)
+    repo.create(tracked_policy_id=TRACKED_POLICY_ID, **OWNER)
+    storage.clear()
+
+    assert repo.get_active_for_tracked_policy(
+        tracked_policy_id=TRACKED_POLICY_ID, **OWNER
+    ) is None

--- a/backend/tests/test_check_execution_service.py
+++ b/backend/tests/test_check_execution_service.py
@@ -1,0 +1,157 @@
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.repositories.in_memory import (
+    InMemoryStorage,
+    InMemoryTrackedPolicyRepository,
+    InMemoryTrackedPolicyCheckExecutionRepository,
+)
+from app.repositories.models import StoredTrackedPolicy
+from app.repositories.policy_capture_status import PolicyCaptureStatus
+from app.repositories.policy_change_status import PolicyChangeStatus
+from app.repositories.policy_tracking_status import PolicyTrackingStatus
+from app.repositories.tracked_policy_check_execution_status import TrackedPolicyCheckExecutionStatus
+from app.services.policy_snapshot_service import (
+    PolicySnapshotCheckFailedError,
+    PolicySnapshotCheckResult,
+    PolicySnapshotTrackedPolicyNotFoundError,
+)
+from app.services.request_subject import RequestSubject
+from app.services.tracked_policy_check_execution_service import (
+    TrackedPolicyCheckExecutionResult,
+    TrackedPolicyCheckExecutionService,
+    TrackedPolicyNotFoundError,
+)
+
+
+class _StubSnapshotService:
+    def __init__(self):
+        self.check_calls = []
+        self.mock_result: PolicySnapshotCheckResult | None = None
+        self.mock_error: Exception | None = None
+
+    def check_tracked_policy(
+        self, *, subject: RequestSubject, tracked_policy_id: UUID
+    ) -> PolicySnapshotCheckResult:
+        self.check_calls.append((subject, tracked_policy_id))
+        if self.mock_error is not None:
+            raise self.mock_error
+        if self.mock_result is not None:
+            return self.mock_result
+        raise NotImplementedError("Stub missing mock_result or mock_error")
+
+
+@pytest.fixture
+def storage():
+    return InMemoryStorage()
+
+
+@pytest.fixture
+def tracked_policy_repository(storage):
+    return InMemoryTrackedPolicyRepository(storage)
+
+
+@pytest.fixture
+def execution_repository(storage):
+    return InMemoryTrackedPolicyCheckExecutionRepository(storage)
+
+
+@pytest.fixture
+def snapshot_service():
+    return _StubSnapshotService()
+
+
+@pytest.fixture
+def execution_service(tracked_policy_repository, execution_repository, snapshot_service):
+    return TrackedPolicyCheckExecutionService(
+        tracked_policy_repository=tracked_policy_repository,
+        check_execution_repository=execution_repository,
+        policy_snapshot_service=snapshot_service,
+    )
+
+
+@pytest.fixture
+def subject():
+    return RequestSubject(subject_type="supabase_user", subject_id="user-a")
+
+
+@pytest.fixture
+def tracked_policy(tracked_policy_repository, subject):
+    return tracked_policy_repository.create(
+        subject_type=subject.subject_type,
+        subject_id=subject.subject_id,
+        canonical_url="https://example.com/terms",
+        display_name="Example Terms",
+        source_type="url",
+        tracking_status=PolicyTrackingStatus.ACTIVE,
+        last_checked_at=None,
+        active=True,
+    )
+
+
+def test_execute_check_raises_not_found_for_missing_policy(execution_service, subject):
+    with pytest.raises(TrackedPolicyNotFoundError):
+        execution_service.execute_check(subject=subject, tracked_policy_id=uuid4())
+
+
+def test_execute_check_creates_successful_execution(
+    execution_service, snapshot_service, subject, tracked_policy
+):
+    snapshot_service.mock_result = PolicySnapshotCheckResult(
+        tracked_policy=tracked_policy, snapshot_created=True
+    )
+
+    result = execution_service.execute_check(subject=subject, tracked_policy_id=tracked_policy.id)
+
+    assert result.execution is not None
+    assert result.execution.status == TrackedPolicyCheckExecutionStatus.SUCCEEDED
+    assert result.execution.result_snapshot_created is True
+    assert result.tracked_policy == tracked_policy
+    assert len(snapshot_service.check_calls) == 1
+
+
+def test_execute_check_deduplicates_active_execution(
+    execution_service, execution_repository, snapshot_service, subject, tracked_policy
+):
+    # Seed an active execution
+    pending_exec = execution_repository.create(
+        tracked_policy_id=tracked_policy.id,
+        subject_type=subject.subject_type,
+        subject_id=subject.subject_id,
+    )
+
+    result = execution_service.execute_check(subject=subject, tracked_policy_id=tracked_policy.id)
+
+    # Deduped result should return the pending execution and the existing policy,
+    # without calling the snapshot service or changing the execution status.
+    assert result.execution.id == pending_exec.id
+    assert result.execution.status == TrackedPolicyCheckExecutionStatus.PENDING
+    assert result.tracked_policy.id == tracked_policy.id
+    assert len(snapshot_service.check_calls) == 0
+
+
+def test_execute_check_handles_capture_failure(
+    execution_service, snapshot_service, subject, tracked_policy
+):
+    error_msg = "Could not connect to the site"
+    snapshot_service.mock_error = PolicySnapshotCheckFailedError(error_msg)
+
+    result = execution_service.execute_check(subject=subject, tracked_policy_id=tracked_policy.id)
+
+    assert result.execution.status == TrackedPolicyCheckExecutionStatus.FAILED
+    assert result.execution.failure_message == error_msg
+    # It still returns the existing policy state when we fail during check.
+    assert result.tracked_policy.id == tracked_policy.id
+
+
+def test_execute_check_classifies_timeout_error(
+    execution_service, snapshot_service, subject, tracked_policy
+):
+    snapshot_service.mock_error = PolicySnapshotCheckFailedError("Analysis timed out after 30s")
+
+    result = execution_service.execute_check(subject=subject, tracked_policy_id=tracked_policy.id)
+
+    assert result.execution.status == TrackedPolicyCheckExecutionStatus.TIMED_OUT
+    assert "timed out" in result.execution.failure_message

--- a/backend/tests/test_check_execution_service.py
+++ b/backend/tests/test_check_execution_service.py
@@ -3,6 +3,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from app.repositories.errors import ActiveTrackedPolicyCheckExecutionConflictError
 from app.repositories.in_memory import (
     InMemoryStorage,
     InMemoryTrackedPolicyRepository,
@@ -21,6 +22,7 @@ from app.services.policy_snapshot_service import (
 from app.services.request_subject import RequestSubject
 from app.services.tracked_policy_check_execution_service import (
     TrackedPolicyCheckExecutionResult,
+    TrackedPolicyCheckExecutionNotFoundError,
     TrackedPolicyCheckExecutionService,
     TrackedPolicyNotFoundError,
 )
@@ -96,6 +98,36 @@ def test_execute_check_raises_not_found_for_missing_policy(execution_service, su
         execution_service.execute_check(subject=subject, tracked_policy_id=uuid4())
 
 
+def test_get_tracked_policy_execution_returns_execution_for_owner(
+    execution_service, execution_repository, subject, tracked_policy
+):
+    created = execution_repository.create(
+        tracked_policy_id=tracked_policy.id,
+        subject_type=subject.subject_type,
+        subject_id=subject.subject_id,
+    )
+
+    execution = execution_service.get_tracked_policy_execution(
+        subject=subject,
+        execution_id=created.id,
+    )
+
+    assert execution.id == created.id
+
+
+def test_get_tracked_policy_execution_raises_not_found_for_unknown_id(execution_service, subject):
+    execution_id = uuid4()
+
+    with pytest.raises(
+        TrackedPolicyCheckExecutionNotFoundError,
+        match=f"Tracked policy check execution {execution_id} was not found.",
+    ):
+        execution_service.get_tracked_policy_execution(
+            subject=subject,
+            execution_id=execution_id,
+        )
+
+
 def test_execute_check_creates_successful_execution(
     execution_service, snapshot_service, subject, tracked_policy
 ):
@@ -129,6 +161,77 @@ def test_execute_check_deduplicates_active_execution(
     assert result.execution.id == pending_exec.id
     assert result.execution.status == TrackedPolicyCheckExecutionStatus.PENDING
     assert result.tracked_policy.id == tracked_policy.id
+    assert len(snapshot_service.check_calls) == 0
+
+
+def test_execute_check_returns_reloaded_active_execution_after_create_conflict(
+    execution_service, execution_repository, snapshot_service, subject, tracked_policy, monkeypatch
+):
+    active_execution = execution_repository.create(
+        tracked_policy_id=tracked_policy.id,
+        subject_type=subject.subject_type,
+        subject_id=subject.subject_id,
+    )
+    active_lookup_results = iter([None, active_execution])
+
+    monkeypatch.setattr(
+        execution_repository,
+        "get_active_for_tracked_policy",
+        lambda **kwargs: next(active_lookup_results),
+    )
+    monkeypatch.setattr(
+        execution_repository,
+        "create",
+        lambda **kwargs: (_ for _ in ()).throw(
+            ActiveTrackedPolicyCheckExecutionConflictError("duplicate active execution")
+        ),
+    )
+    monkeypatch.setattr(
+        execution_repository,
+        "mark_running",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("mark_running should not be called after a create conflict")
+        ),
+    )
+
+    result = execution_service.execute_check(subject=subject, tracked_policy_id=tracked_policy.id)
+
+    assert result.execution.id == active_execution.id
+    assert result.tracked_policy.id == tracked_policy.id
+    assert len(snapshot_service.check_calls) == 0
+
+
+def test_execute_check_raises_runtime_error_when_conflict_cannot_be_reloaded(
+    execution_service, execution_repository, snapshot_service, subject, tracked_policy, monkeypatch
+):
+    active_lookup_results = iter([None, None])
+
+    monkeypatch.setattr(
+        execution_repository,
+        "get_active_for_tracked_policy",
+        lambda **kwargs: next(active_lookup_results),
+    )
+    monkeypatch.setattr(
+        execution_repository,
+        "create",
+        lambda **kwargs: (_ for _ in ()).throw(
+            ActiveTrackedPolicyCheckExecutionConflictError("duplicate active execution")
+        ),
+    )
+    monkeypatch.setattr(
+        execution_repository,
+        "mark_running",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("mark_running should not be called after a create conflict")
+        ),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="create conflicted, but no active execution could be reloaded",
+    ):
+        execution_service.execute_check(subject=subject, tracked_policy_id=tracked_policy.id)
+
     assert len(snapshot_service.check_calls) == 0
 
 

--- a/backend/tests/test_tracked_policies_api.py
+++ b/backend/tests/test_tracked_policies_api.py
@@ -20,6 +20,7 @@ from app.repositories.in_memory import (
     InMemoryPolicySnapshotRepository,
     InMemoryReportRepository,
     InMemoryStorage,
+    InMemoryTrackedPolicyCheckExecutionRepository,
     InMemoryTrackedPolicyRepository,
 )
 from app.repositories.models import PolicySnapshotCreateInput
@@ -217,6 +218,7 @@ def _build_shared_services(
     agreement_repository = InMemoryAgreementRepository(storage)
     report_repository = InMemoryReportRepository(storage)
     tracked_policy_repository = InMemoryTrackedPolicyRepository(storage)
+    check_execution_repository = InMemoryTrackedPolicyCheckExecutionRepository(storage)
     policy_snapshot_repository = InMemoryPolicySnapshotRepository(storage)
     policy_change_event_repository = InMemoryPolicyChangeEventRepository(storage)
     effective_analysis_service = analysis_service or AnalysisOrchestrationService(
@@ -232,6 +234,7 @@ def _build_shared_services(
     tracked_policy_service = TrackedPolicyService(
         tracked_policy_repository=tracked_policy_repository,
         policy_snapshot_repository=policy_snapshot_repository,
+        check_execution_repository=check_execution_repository,
         analysis_service=effective_analysis_service,
         policy_change_event_repository=policy_change_event_repository,
         public_web_source_inspector=effective_inspector,
@@ -575,8 +578,9 @@ def test_tracked_policy_check_returns_actionable_error_and_marks_policy_invalid_
         headers=owner_headers,
     )
 
-    assert check_response.status_code == 422
-    message = check_response.json()["detail"].lower()
+    assert check_response.status_code == 200
+    assert check_response.json()["execution"]["status"] == "failed"
+    message = check_response.json()["execution"]["failure_message"].lower()
     assert "blocking access" in message
     assert "does not require sign-in" in message
 
@@ -627,11 +631,13 @@ def test_tracked_policy_check_returns_no_change_message_without_creating_duplica
     )
 
     assert check_response.status_code == 200
-    assert check_response.json()["latest_change_status"] == "unchanged"
-    assert check_response.json()["snapshot_version_count"] == 1
+    assert check_response.json()["execution"]["status"] == "succeeded"
+    tracked_policy = check_response.json()["tracked_policy"]
+    assert tracked_policy["latest_change_status"] == "unchanged"
+    assert tracked_policy["snapshot_version_count"] == 1
     assert (
         "no meaningful policy changes"
-        in (check_response.json()["latest_capture_message"] or "").lower()
+        in (tracked_policy["latest_capture_message"] or "").lower()
     )
 
 
@@ -669,10 +675,12 @@ def test_tracked_policy_check_creates_new_snapshot_when_content_changes(
     )
 
     assert check_response.status_code == 200
-    assert check_response.json()["latest_change_status"] == "updated"
-    assert check_response.json()["latest_change_detected_at"] is not None
-    assert check_response.json()["snapshot_version_count"] == 2
-    assert check_response.json()["latest_capture_message"] is None
+    assert check_response.json()["execution"]["status"] == "succeeded"
+    tracked_policy = check_response.json()["tracked_policy"]
+    assert tracked_policy["latest_change_status"] == "updated"
+    assert tracked_policy["latest_change_detected_at"] is not None
+    assert tracked_policy["snapshot_version_count"] == 2
+    assert tracked_policy["latest_capture_message"] is None
 
     report_list_response = client.get("/api/v1/reports", headers=owner_headers)
     report_list = report_list_response.json()
@@ -702,6 +710,7 @@ def test_tracked_policy_check_returns_actionable_error_and_does_not_increment_ve
     timeout_analysis_service = _TimeoutTrackedSnapshotAnalysisService(analysis_service)
     tracked_policy_service = TrackedPolicyService(
         tracked_policy_repository=tracked_policy_service._tracked_policy_repository,  # type: ignore[attr-defined]
+        check_execution_repository=tracked_policy_service._check_execution_service._check_execution_repository,  # type: ignore[attr-defined]
         policy_snapshot_repository=tracked_policy_service._policy_snapshot_repository,  # type: ignore[attr-defined]
         analysis_service=timeout_analysis_service,
         policy_change_event_repository=tracked_policy_service._policy_snapshot_service._policy_change_event_repository,  # type: ignore[attr-defined]
@@ -723,8 +732,9 @@ def test_tracked_policy_check_returns_actionable_error_and_does_not_increment_ve
         headers=owner_headers,
     )
 
-    assert check_response.status_code == 422
-    assert "timed out" in check_response.json()["detail"].lower()
+    assert check_response.status_code == 200
+    assert check_response.json()["execution"]["status"] == "timed_out"
+    assert "timed out" in check_response.json()["execution"]["failure_message"].lower()
 
     list_response = client.get("/api/v1/tracked-policies", headers=owner_headers)
     tracked_policies = list_response.json()
@@ -946,3 +956,45 @@ def test_tracked_policy_compare_rejects_duplicate_snapshot_ids(
 
     assert compare_response.status_code == 422
     assert "choose two different" in compare_response.json()["detail"].lower()
+
+
+def test_tracked_policy_execution_status_returns_execution_record(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checked_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+    tracked_policy_service, analysis_service = _build_shared_services(
+        inspector=_InspectorDouble(
+            InspectedWebSource(
+                canonical_url="https://example.com/terms",
+                display_name="Example Terms",
+                source_type="url",
+                last_checked_at=checked_at,
+            )
+        )
+    )
+    monkeypatch.setattr(deps, "_tracked_policy_service", tracked_policy_service)
+    monkeypatch.setattr(deps, "_analysis_service", analysis_service)
+    owner_headers = _auth_headers("auth-user-a")
+
+    create_response = client.post(
+        "/api/v1/tracked-policies",
+        json={"source_url": "https://example.com/terms"},
+        headers=owner_headers,
+    )
+    tracked_policy_id = create_response.json()["id"]
+
+    check_response = client.post(
+        f"/api/v1/tracked-policies/{tracked_policy_id}/check",
+        headers=owner_headers,
+    )
+    execution_id = check_response.json()["execution"]["id"]
+
+    status_response = client.get(
+        f"/api/v1/tracked-policies/executions/{execution_id}",
+        headers=owner_headers,
+    )
+
+    assert status_response.status_code == 200
+    assert status_response.json()["id"] == execution_id
+    assert status_response.json()["status"] == "succeeded"
+    assert status_response.json()["tracked_policy_id"] == tracked_policy_id

--- a/backend/tests/test_tracked_policies_api.py
+++ b/backend/tests/test_tracked_policies_api.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from uuid import uuid4
 
 from fastapi.testclient import TestClient
 import httpx
@@ -636,8 +637,7 @@ def test_tracked_policy_check_returns_no_change_message_without_creating_duplica
     assert tracked_policy["latest_change_status"] == "unchanged"
     assert tracked_policy["snapshot_version_count"] == 1
     assert (
-        "no meaningful policy changes"
-        in (tracked_policy["latest_capture_message"] or "").lower()
+        "no meaningful policy changes" in (tracked_policy["latest_capture_message"] or "").lower()
     )
 
 
@@ -998,3 +998,24 @@ def test_tracked_policy_execution_status_returns_execution_record(
     assert status_response.json()["id"] == execution_id
     assert status_response.json()["status"] == "succeeded"
     assert status_response.json()["tracked_policy_id"] == tracked_policy_id
+
+
+def test_tracked_policy_execution_status_returns_404_for_unknown_execution(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tracked_policy_service, analysis_service = _build_shared_services()
+    monkeypatch.setattr(deps, "_tracked_policy_service", tracked_policy_service)
+    monkeypatch.setattr(deps, "_analysis_service", analysis_service)
+    owner_headers = _auth_headers("auth-user-a")
+    execution_id = uuid4()
+
+    status_response = client.get(
+        f"/api/v1/tracked-policies/executions/{execution_id}",
+        headers=owner_headers,
+    )
+
+    assert status_response.status_code == 404
+    assert (
+        status_response.json()["detail"]
+        == f"Tracked policy check execution {execution_id} was not found."
+    )

--- a/backend/tests/test_tracked_policies_api.py
+++ b/backend/tests/test_tracked_policies_api.py
@@ -1019,3 +1019,21 @@ def test_tracked_policy_execution_status_returns_404_for_unknown_execution(
         status_response.json()["detail"]
         == f"Tracked policy check execution {execution_id} was not found."
     )
+
+
+def test_tracked_policy_check_returns_404_for_unknown_tracked_policy(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tracked_policy_service, analysis_service = _build_shared_services()
+    monkeypatch.setattr(deps, "_tracked_policy_service", tracked_policy_service)
+    monkeypatch.setattr(deps, "_analysis_service", analysis_service)
+    owner_headers = _auth_headers("auth-user-a")
+    tracked_policy_id = uuid4()
+
+    check_response = client.post(
+        f"/api/v1/tracked-policies/{tracked_policy_id}/check",
+        headers=owner_headers,
+    )
+
+    assert check_response.status_code == 404
+    assert check_response.json()["detail"] == f"Tracked policy {tracked_policy_id} was not found."

--- a/backend/tests/test_tracked_policy_service.py
+++ b/backend/tests/test_tracked_policy_service.py
@@ -9,12 +9,14 @@ from app.repositories.in_memory import (
     InMemoryPolicySnapshotRepository,
     InMemoryReportRepository,
     InMemoryStorage,
+    InMemoryTrackedPolicyCheckExecutionRepository,
     InMemoryTrackedPolicyRepository,
 )
 from app.repositories.policy_capture_status import PolicyCaptureStatus
 from app.repositories.policy_change_status import PolicyChangeStatus
 from app.repositories.policy_tracking_status import PolicyTrackingStatus
 from app.repositories.report_capture_kind import ReportContentCaptureKind
+from app.repositories.tracked_policy_check_execution_status import TrackedPolicyCheckExecutionStatus
 from app.services.ai_provider import DeterministicAnalysisProvider
 from app.services.analysis_execution import SyncAnalysisExecutionStrategy
 from app.services.analysis_service import (
@@ -192,6 +194,7 @@ def _build_services(
 ) -> tuple[TrackedPolicyService, AnalysisOrchestrationService | _FailingBaselineAnalysisService]:
     storage = InMemoryStorage()
     tracked_policy_repository = InMemoryTrackedPolicyRepository(storage)
+    check_execution_repository = InMemoryTrackedPolicyCheckExecutionRepository(storage)
     policy_snapshot_repository = InMemoryPolicySnapshotRepository(storage)
     policy_change_event_repository = InMemoryPolicyChangeEventRepository(storage)
 
@@ -213,6 +216,7 @@ def _build_services(
         TrackedPolicyService(
             tracked_policy_repository=tracked_policy_repository,
             policy_snapshot_repository=policy_snapshot_repository,
+            check_execution_repository=check_execution_repository,
             analysis_service=effective_analysis_service,
             policy_change_event_repository=policy_change_event_repository,
             public_web_source_inspector=inspector,
@@ -534,15 +538,14 @@ def test_tracked_policy_service_marks_policy_invalid_source_and_does_not_create_
         source_url="https://example.com/terms",
     )
 
-    with pytest.raises(TrackedPolicyCheckFailedError) as error_info:
-        service.check_tracked_policy(
-            subject=subject,
-            tracked_policy_id=enrollment.tracked_policy.id,
-        )
+    result = service.check_tracked_policy(
+        subject=subject,
+        tracked_policy_id=enrollment.tracked_policy.id,
+    )
 
-    message = str(error_info.value).lower()
-    assert "404 not found" in message
-    assert "public legal page" in message
+    assert result.execution.status == TrackedPolicyCheckExecutionStatus.FAILED
+    assert "404 not found" in (result.execution.failure_message or "").lower()
+    assert "public legal page" in (result.execution.failure_message or "").lower()
 
     tracked_policies = service.list_tracked_policies(subject=subject)
     assert len(tracked_policies) == 1
@@ -574,11 +577,13 @@ def test_tracked_policy_check_does_not_create_new_saved_reports() -> None:
         source_url="https://example.com/terms",
     )
 
-    updated = service.check_tracked_policy(
+    result = service.check_tracked_policy(
         subject=subject,
         tracked_policy_id=enrollment.tracked_policy.id,
     )
+    updated = result.tracked_policy
 
+    assert updated is not None
     assert updated.tracking_status == PolicyTrackingStatus.ACTIVE
     assert updated.latest_capture_status == PolicyCaptureStatus.CAPTURED
     assert updated.latest_change_status == PolicyChangeStatus.UNCHANGED
@@ -609,11 +614,13 @@ def test_tracked_policy_check_does_not_increment_version_count_when_baseline_sna
         source_url="https://example.com/terms",
     )
 
-    updated = service.check_tracked_policy(
+    result = service.check_tracked_policy(
         subject=subject,
         tracked_policy_id=enrollment.tracked_policy.id,
     )
+    updated = result.tracked_policy
 
+    assert updated is not None
     assert updated.latest_capture_status == PolicyCaptureStatus.CAPTURED
     assert updated.latest_change_status == PolicyChangeStatus.UNCHANGED
     assert "no meaningful policy changes" in (updated.latest_capture_message or "").lower()
@@ -642,10 +649,12 @@ def test_tracked_policy_check_creates_saved_report_for_new_snapshot_version() ->
         source_url="https://example.com/terms",
     )
 
-    updated = service.check_tracked_policy(
+    result = service.check_tracked_policy(
         subject=subject,
         tracked_policy_id=enrollment.tracked_policy.id,
     )
+    updated = result.tracked_policy
+    assert updated is not None
 
     reports = analysis_service.list_reports(subject=subject)
     assert updated.latest_change_status == PolicyChangeStatus.UPDATED

--- a/docs/scrum-104-async-execution.md
+++ b/docs/scrum-104-async-execution.md
@@ -1,0 +1,66 @@
+# Tracked Policy Async Execution (SCRUM-104)
+
+This document outlines the architecture introduced in SCRUM-104, transforming the tracked-policy manual re-check flow into a durable, explicitly tracked execution model.
+
+## What Is Async-Ready Now
+
+The manual tracked-policy check endpoint has been migrated to the new async-ready execution model:
+- `POST /api/v1/tracked-policies/{id}/check`
+
+This endpoint no longer returns a bare `TrackedPolicyResponse`. Instead, it routes through an async-ready orchestration layer (`TrackedPolicyCheckExecutionService`) and returns a response envelope that tracks the status of the check run:
+
+```json
+{
+  "execution": {
+    "status": "pending | running | succeeded | failed | timed_out"
+  },
+  "tracked_policy": { "...": "present for inline results or deduped active executions" }
+}
+```
+
+The frontend client fully supports this envelope and polls `GET /api/v1/tracked-policies/executions/{id}`.
+
+## Synchronous and Out of Scope
+
+The following flows were deliberately not refactored in SCRUM-104 and remain on synchronous or external-scheduler tracks:
+- Report analysis
+- Agreement submission
+- Scheduled scans
+- RabbitMQ / generic background workers
+
+## Future Queue Handoff Point
+
+Currently, `TrackedPolicyCheckExecutionService.execute_check()` invokes the synchronous business logic (`PolicySnapshotService.check_tracked_policy()`) inline on the web-server thread.
+
+The cleanly defined handoff point for SCRUM-115 is `execute_check()` or a hook immediately after execution creation. When a queue is introduced, the web thread should create the execution, leave it in `pending`, and publish a message. A background worker would then transition the execution to `running`, execute the core check logic, and apply the terminal transition (`succeeded`, `failed`, or `timed_out`).
+
+## Dedupe Rule
+
+A strict active-execution deduplication rule exists to prevent multiple overlapping scrapes for the same policy.
+- An execution is active if it is in the `pending` or `running` state.
+- In-memory repositories enforce this via programmatic lookups plus create-time conflict checks.
+- Postgres enforces this via a partial unique index on `(tracked_policy_id, subject_type, subject_id)` where `status IN ('pending', 'running')`.
+
+Repeated requests to `POST /check` while an execution is active will not trigger a new run. Instead, the orchestrator returns the existing active execution record so the frontend can poll it.
+
+## Execution Lifecycle States
+
+The execution model supports strict, valid transitions to prevent silent failures and invalid jumps:
+
+1. `pending`: The execution record has been created and may later be queued.
+2. `running`: The execution has begun evaluating the source policy.
+3. `succeeded`: The scrape and comparison completed successfully.
+4. `failed`: An application error, missing dependency, or structured failure occurred.
+5. `timed_out`: The underlying dependency explicitly timed out.
+
+Rules:
+- State should progress forward as `pending -> running -> (succeeded | failed | timed_out)`.
+- Direct `pending -> terminal` completion is still allowed for failure paths that complete before a running transition is recorded.
+- No invalid or silent jump transitions are permitted. Failure metadata is preserved through structured fields such as `failure_message`.
+
+## Timeout and Retry Expectations
+
+Expectations for tracked-policy checks:
+- Timeout extraction: timeout-like exceptions from lower layers are explicitly classified into the `timed_out` state so infrastructure congestion is distinguishable from persistent bad-data or application failures (`failed`).
+- Failure delivery: the execution status endpoint returns terminal failures as JSON with `status: failed | timed_out`; the frontend converts those terminal states into user-visible errors locally instead of relying on non-2xx HTTP responses.
+- Retries: under the current monolith implementation, retries are manual. Users can click the check button again after an execution fails or times out. In a queued deployment, exhausted automatic retries would eventually transition to `failed` or `timed_out` with structured fallback detail.

--- a/frontend/src/features/dashboard/hooks/useTrackedPolicies.ts
+++ b/frontend/src/features/dashboard/hooks/useTrackedPolicies.ts
@@ -155,7 +155,8 @@ export function useTrackedPolicies(apiClient: DashboardApiClient): UseTrackedPol
           setSelectedTrackedPolicy(refreshedPolicy);
         }
 
-        const policyResponse = envelope.tracked_policy || trackedPoliciesResponse.find((p) => p.id === trackedPolicyId);
+        const policyResponse =
+          trackedPoliciesResponse.find((p) => p.id === trackedPolicyId) || envelope.tracked_policy;
         if (!policyResponse) {
           throw new Error('Failed to load checked policy.');
         }

--- a/frontend/src/features/dashboard/hooks/useTrackedPolicies.ts
+++ b/frontend/src/features/dashboard/hooks/useTrackedPolicies.ts
@@ -19,6 +19,11 @@ import type {
   DashboardTrackedPolicySnapshot,
 } from '../types';
 
+const EXECUTION_POLL_INTERVAL_MS = 2000;
+const EXECUTION_POLL_MAX_ATTEMPTS = 30;
+const EXECUTION_POLL_TIMEOUT_MESSAGE =
+  'Policy check is taking longer than expected. Please refresh and try again.';
+
 interface UseTrackedPoliciesResult {
   trackedPolicies: DashboardTrackedPolicy[];
   isLoadingTrackedPolicies: boolean;
@@ -136,9 +141,14 @@ export function useTrackedPolicies(apiClient: DashboardApiClient): UseTrackedPol
       try {
         const envelope = await apiClient.checkTrackedPolicy(trackedPolicyId);
         let execution = envelope.execution;
-        
+        let pollAttemptsRemaining = EXECUTION_POLL_MAX_ATTEMPTS;
+
         while (execution.status === 'pending' || execution.status === 'running') {
-          await new Promise((resolve) => setTimeout(resolve, 2000));
+          if (pollAttemptsRemaining <= 0) {
+            throw new Error(EXECUTION_POLL_TIMEOUT_MESSAGE);
+          }
+          pollAttemptsRemaining -= 1;
+          await new Promise((resolve) => setTimeout(resolve, EXECUTION_POLL_INTERVAL_MS));
           execution = await apiClient.getTrackedPolicyExecution(execution.id);
         }
 

--- a/frontend/src/features/dashboard/hooks/useTrackedPolicies.ts
+++ b/frontend/src/features/dashboard/hooks/useTrackedPolicies.ts
@@ -134,41 +134,57 @@ export function useTrackedPolicies(apiClient: DashboardApiClient): UseTrackedPol
       setErrorMessage(null);
       setSuccessMessage(null);
       try {
-        const checkedTrackedPolicy = await apiClient.checkTrackedPolicy(trackedPolicyId);
+        const envelope = await apiClient.checkTrackedPolicy(trackedPolicyId);
+        let execution = envelope.execution;
+        
+        while (execution.status === 'pending' || execution.status === 'running') {
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+          execution = await apiClient.getTrackedPolicyExecution(execution.id);
+        }
+
+        if (execution.status === 'failed' || execution.status === 'timed_out') {
+          throw new Error(execution.failure_message || 'Failed to check the policy for updates.');
+        }
+
         const trackedPoliciesResponse = await apiClient.listTrackedPolicies();
         const mappedTrackedPolicies = trackedPoliciesResponse.map(mapTrackedPolicy);
         setTrackedPolicies(mappedTrackedPolicies);
-        if (selectedTrackedPolicy?.id === trackedPolicyId) {
-          setSelectedTrackedPolicy(
-            mappedTrackedPolicies.find((trackedPolicy) => trackedPolicy.id === trackedPolicyId) ??
-              selectedTrackedPolicy,
-          );
+
+        const refreshedPolicy = mappedTrackedPolicies.find((p) => p.id === trackedPolicyId);
+        if (selectedTrackedPolicy?.id === trackedPolicyId && refreshedPolicy) {
+          setSelectedTrackedPolicy(refreshedPolicy);
         }
-        if (checkedTrackedPolicy.latest_capture_message) {
-          setSuccessMessage(checkedTrackedPolicy.latest_capture_message);
-        } else if (checkedTrackedPolicy.latest_change_status === 'updated') {
+
+        const policyResponse = envelope.tracked_policy || trackedPoliciesResponse.find((p) => p.id === trackedPolicyId);
+        if (!policyResponse) {
+          throw new Error('Failed to load checked policy.');
+        }
+
+        if (policyResponse.latest_capture_message) {
+          setSuccessMessage(policyResponse.latest_capture_message);
+        } else if (policyResponse.latest_change_status === 'updated') {
           setSuccessMessage(
-            `${checkedTrackedPolicy.display_name} was checked and a policy update was detected.`,
+            `${policyResponse.display_name} was checked and a policy update was detected.`,
           );
-        } else if (checkedTrackedPolicy.latest_change_status === 'not_evaluated') {
+        } else if (policyResponse.latest_change_status === 'not_evaluated') {
           setSuccessMessage(
-            `${checkedTrackedPolicy.display_name} was checked and stored as its first tracked version.`,
+            `${policyResponse.display_name} was checked and stored as its first tracked version.`,
           );
-        } else if (checkedTrackedPolicy.latest_change_status === 'unchanged') {
+        } else if (policyResponse.latest_change_status === 'unchanged') {
           setSuccessMessage(
-            `${checkedTrackedPolicy.display_name} was checked and no meaningful policy changes were detected.`,
+            `${policyResponse.display_name} was checked and no meaningful policy changes were detected.`,
           );
-        } else if (checkedTrackedPolicy.latest_change_status === 'comparison_incomplete') {
+        } else if (policyResponse.latest_change_status === 'comparison_incomplete') {
           setSuccessMessage(
-            `${checkedTrackedPolicy.display_name} was checked, but the latest comparison could not be completed.`,
+            `${policyResponse.display_name} was checked, but the latest comparison could not be completed.`,
           );
         } else {
           const versionLabel =
-            checkedTrackedPolicy.snapshot_version_count === 1
+            policyResponse.snapshot_version_count === 1
               ? '1 stored version'
-              : `${checkedTrackedPolicy.snapshot_version_count} stored versions`;
+              : `${policyResponse.snapshot_version_count} stored versions`;
           setSuccessMessage(
-            `${checkedTrackedPolicy.display_name} was checked and now has ${versionLabel}.`,
+            `${policyResponse.display_name} was checked and now has ${versionLabel}.`,
           );
         }
       } catch (error) {

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -16,6 +16,8 @@ import type {
   TrackedPolicySnapshotComparisonResponse,
   TrackedPolicySnapshotResponse,
   TrackedPolicyResponse,
+  TrackedPolicyCheckExecutionEnvelope,
+  TrackedPolicyCheckExecutionResponse,
 } from './contracts';
 import {
   sanitizeAgreementCreateInput,
@@ -101,12 +103,19 @@ export class DashboardApiClient {
     return this.request<TrackedPolicyResponse[]>('/tracked-policies');
   }
 
-  async checkTrackedPolicy(trackedPolicyId: string): Promise<TrackedPolicyResponse> {
-    return this.request<TrackedPolicyResponse>(
+  async checkTrackedPolicy(trackedPolicyId: string): Promise<TrackedPolicyCheckExecutionEnvelope> {
+    return this.request<TrackedPolicyCheckExecutionEnvelope>(
       `/tracked-policies/${validateUuid(trackedPolicyId, 'Tracked policy id')}/check`,
       {
         method: 'POST',
       },
+      { timeoutMs: LONG_RUNNING_REQUEST_TIMEOUT_MS }
+    );
+  }
+
+  async getTrackedPolicyExecution(executionId: string): Promise<TrackedPolicyCheckExecutionResponse> {
+    return this.request<TrackedPolicyCheckExecutionResponse>(
+      `/tracked-policies/executions/${validateUuid(executionId, 'Execution id')}`
     );
   }
 

--- a/frontend/src/lib/api/contracts.ts
+++ b/frontend/src/lib/api/contracts.ts
@@ -43,6 +43,21 @@ export interface TrackedPolicyCreateResponse extends TrackedPolicyResponse {
   baseline_report_action: 'created' | 'reused';
 }
 
+export interface TrackedPolicyCheckExecutionResponse {
+  id: string;
+  tracked_policy_id: string;
+  status: string; // 'pending' | 'running' | 'succeeded' | 'failed' | 'timed_out'
+  result_snapshot_created: boolean | null;
+  failure_message: string | null;
+  execute_started_at: string | null;
+  execute_finished_at: string | null;
+}
+
+export interface TrackedPolicyCheckExecutionEnvelope {
+  execution: TrackedPolicyCheckExecutionResponse;
+  tracked_policy: TrackedPolicyResponse | null;
+}
+
 export interface TrackedPolicySnapshotResponse {
   snapshot_id: string;
   version_number: number;

--- a/frontend/tests/dashboard.test.tsx
+++ b/frontend/tests/dashboard.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -145,6 +145,7 @@ function buildTrackedPolicyComparison(
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.restoreAllMocks();
   window.localStorage.clear();
 });
@@ -1297,5 +1298,80 @@ describe('DashboardPage', () => {
       { timeout: 4000 },
     );
     expect(screen.getByText('2 stored versions')).toBeTruthy();
+  });
+
+  it('stops polling and shows an error when execution never reaches a terminal state', async () => {
+    vi.useFakeTimers();
+
+    const trackedPolicyId = '20000000-0000-4000-8000-000000000101';
+    const executionId = '50000000-0000-4000-8000-000000000101';
+    const trackedPolicy = buildTrackedPolicy({
+      id: trackedPolicyId,
+      display_name: 'Stuck Execution Terms',
+    });
+    let executionPollCount = 0;
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+
+      if (url.endsWith('/reports') && method === 'GET') {
+        return jsonResponse([]);
+      }
+
+      if (url.endsWith('/tracked-policies') && method === 'GET') {
+        return jsonResponse([trackedPolicy]);
+      }
+
+      if (url.endsWith(`/tracked-policies/${trackedPolicyId}/check`) && method === 'POST') {
+        return jsonResponse({
+          execution: {
+            id: executionId,
+            tracked_policy_id: trackedPolicyId,
+            status: 'running',
+            result_snapshot_created: null,
+            failure_message: null,
+            execute_started_at: '2026-03-25T09:00:00Z',
+            execute_finished_at: null,
+          },
+          tracked_policy: trackedPolicy,
+        });
+      }
+
+      if (url.endsWith(`/executions/${executionId}`) && method === 'GET') {
+        executionPollCount += 1;
+        return jsonResponse({
+          id: executionId,
+          tracked_policy_id: trackedPolicyId,
+          status: 'running',
+          result_snapshot_created: null,
+          failure_message: null,
+          execute_started_at: '2026-03-25T09:00:00Z',
+          execute_finished_at: null,
+        });
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<DashboardPage />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText('Stuck Execution Terms')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check now' }));
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(
+      screen.getByText('Policy check is taking longer than expected. Please refresh and try again.'),
+    ).toBeTruthy();
+    expect(executionPollCount).toBe(30);
   });
 });

--- a/frontend/tests/dashboard.test.tsx
+++ b/frontend/tests/dashboard.test.tsx
@@ -1218,4 +1218,84 @@ describe('DashboardPage', () => {
     expect(screen.getByText('2 stored versions')).toBeTruthy();
     expect(screen.getByText(/updated/i)).toBeTruthy();
   });
+
+  it('prefers refreshed tracked-policy state over stale check-envelope state after polling', async () => {
+    const trackedPolicyId = '20000000-0000-4000-8000-000000000100';
+    const executionId = '50000000-0000-4000-8000-000000000100';
+    const staleEnvelopeTrackedPolicy = buildTrackedPolicy({
+      id: trackedPolicyId,
+      display_name: 'Refresh Wins Terms',
+      latest_change_status: 'unchanged',
+      snapshot_version_count: 1,
+    });
+    const refreshedTrackedPolicy = buildTrackedPolicy({
+      ...staleEnvelopeTrackedPolicy,
+      latest_change_status: 'updated',
+      snapshot_version_count: 2,
+    });
+
+    let pollCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+
+      if (url.endsWith('/reports') && method === 'GET') {
+        return jsonResponse([]);
+      }
+
+      if (url.endsWith('/tracked-policies') && method === 'GET') {
+        if (pollCount >= 1) {
+          return jsonResponse([refreshedTrackedPolicy]);
+        }
+        return jsonResponse([staleEnvelopeTrackedPolicy]);
+      }
+
+      if (url.endsWith(`/tracked-policies/${trackedPolicyId}/check`) && method === 'POST') {
+        return jsonResponse({
+          execution: {
+            id: executionId,
+            tracked_policy_id: trackedPolicyId,
+            status: 'running',
+            result_snapshot_created: null,
+            failure_message: null,
+            execute_started_at: '2026-03-25T09:00:00Z',
+            execute_finished_at: null,
+          },
+          tracked_policy: staleEnvelopeTrackedPolicy,
+        });
+      }
+
+      if (url.endsWith(`/executions/${executionId}`) && method === 'GET') {
+        pollCount += 1;
+        return jsonResponse({
+          id: executionId,
+          tracked_policy_id: trackedPolicyId,
+          status: 'succeeded',
+          result_snapshot_created: true,
+          failure_message: null,
+          execute_started_at: '2026-03-25T09:00:00Z',
+          execute_finished_at: '2026-03-25T09:00:05Z',
+        });
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => expect(screen.getByText('Refresh Wins Terms')).toBeTruthy());
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Check now' }));
+
+    await waitFor(
+      () =>
+        expect(
+          screen.getByText('Refresh Wins Terms was checked and a policy update was detected.'),
+        ).toBeTruthy(),
+      { timeout: 4000 },
+    );
+    expect(screen.getByText('2 stored versions')).toBeTruthy();
+  });
 });

--- a/frontend/tests/dashboard.test.tsx
+++ b/frontend/tests/dashboard.test.tsx
@@ -196,7 +196,7 @@ describe('DashboardPage', () => {
   });
 
   it('shows loading and empty states while report history is fetched', async () => {
-    let resolveRequest: ((response: Response) => void) | null = null;
+    let resolveRequest!: (value: Response) => void;
     const pending = new Promise<Response>((resolve) => {
       resolveRequest = resolve;
     });
@@ -217,7 +217,7 @@ describe('DashboardPage', () => {
     render(<DashboardPage />);
     expect(screen.getByText('Loading report history...')).toBeTruthy();
 
-    resolveRequest?.(jsonResponse([]));
+    resolveRequest(jsonResponse([]));
 
     await waitFor(() =>
       expect(screen.getByText('No reports yet. Submit a terms agreement to create one.')).toBeTruthy(),
@@ -642,13 +642,18 @@ describe('DashboardPage', () => {
         url.endsWith('/tracked-policies/20000000-0000-4000-8000-000000000003/check') &&
         method === 'POST'
       ) {
-        return jsonResponse(
-          {
-            detail:
-              'That policy page is blocking access. Use a public terms or privacy page that does not require sign-in.',
+        return jsonResponse({
+          execution: {
+            id: '50000000-0000-4000-8000-000000000003',
+            tracked_policy_id: '20000000-0000-4000-8000-000000000003',
+            status: 'failed',
+            result_snapshot_created: false,
+            failure_message: 'That policy page is blocking access. Use a public terms or privacy page that does not require sign-in.',
+            execute_started_at: '2026-03-24T15:30:00Z',
+            execute_finished_at: '2026-03-24T15:30:01Z',
           },
-          422,
-        );
+          tracked_policy: failedTrackedPolicy,
+        });
       }
       throw new Error(`Unexpected request: ${method} ${url}`);
     });
@@ -716,7 +721,18 @@ describe('DashboardPage', () => {
         url.endsWith('/tracked-policies/20000000-0000-4000-8000-000000000005/check') &&
         method === 'POST'
       ) {
-        return jsonResponse(unchangedTrackedPolicy);
+        return jsonResponse({
+          execution: {
+            id: '50000000-0000-4000-8000-000000000005',
+            tracked_policy_id: '20000000-0000-4000-8000-000000000005',
+            status: 'succeeded',
+            result_snapshot_created: false,
+            failure_message: null,
+            execute_started_at: '2026-03-24T15:30:00Z',
+            execute_finished_at: '2026-03-24T15:30:01Z',
+          },
+          tracked_policy: unchangedTrackedPolicy,
+        });
       }
       throw new Error(`Unexpected request: ${method} ${url}`);
     });
@@ -921,7 +937,18 @@ describe('DashboardPage', () => {
         url.endsWith('/tracked-policies/20000000-0000-4000-8000-000000000011/check') &&
         method === 'POST'
       ) {
-        return jsonResponse(updatedTrackedPolicy);
+        return jsonResponse({
+          execution: {
+            id: '50000000-0000-4000-8000-000000000011',
+            tracked_policy_id: '20000000-0000-4000-8000-000000000011',
+            status: 'succeeded',
+            result_snapshot_created: true,
+            failure_message: null,
+            execute_started_at: '2026-03-25T09:00:00Z',
+            execute_finished_at: '2026-03-25T09:00:01Z',
+          },
+          tracked_policy: updatedTrackedPolicy,
+        });
       }
       throw new Error(`Unexpected request: ${method} ${url}`);
     });
@@ -1095,5 +1122,100 @@ describe('DashboardPage', () => {
     expect(
       screen.getByText('No tracked policies yet. Add a policy URL to start monitoring changes.'),
     ).toBeTruthy();
+  });
+
+  it('polls execution status until it succeeds', async () => {
+    const trackedPolicyId = '20000000-0000-4000-8000-000000000099';
+    const executionId = '50000000-0000-4000-8000-000000000099';
+    const initialTrackedPolicy = buildTrackedPolicy({
+      id: trackedPolicyId,
+      canonical_url: 'https://example.com/legal/terms',
+      display_name: 'Slow Term Checks',
+      snapshot_version_count: 1,
+      latest_change_status: 'unchanged',
+    });
+    
+    const updatedTrackedPolicy = buildTrackedPolicy({
+      ...initialTrackedPolicy,
+      latest_change_status: 'updated',
+      snapshot_version_count: 2,
+    });
+
+    let pollCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+
+      if (url.endsWith('/reports') && method === 'GET') {
+        return jsonResponse([]);
+      }
+      
+      if (url.endsWith('/tracked-policies') && method === 'GET') {
+        if (pollCount >= 2) {
+            return jsonResponse([updatedTrackedPolicy]);
+        }
+        return jsonResponse([initialTrackedPolicy]);
+      }
+      
+      if (url.endsWith(`/tracked-policies/${trackedPolicyId}/check`) && method === 'POST') {
+        return jsonResponse({
+          execution: {
+            id: executionId,
+            tracked_policy_id: trackedPolicyId,
+            status: 'running',
+            result_snapshot_created: null,
+            failure_message: null,
+            execute_started_at: '2026-03-25T09:00:00Z',
+            execute_finished_at: null,
+          },
+          tracked_policy: null,
+        });
+      }
+      
+      if (url.endsWith(`/executions/${executionId}`) && method === 'GET') {
+        pollCount += 1;
+        if (pollCount < 2) {
+            return jsonResponse({
+                id: executionId,
+                tracked_policy_id: trackedPolicyId,
+                status: 'running',
+                result_snapshot_created: null,
+                failure_message: null,
+                execute_started_at: '2026-03-25T09:00:00Z',
+                execute_finished_at: null,
+            });
+        }
+
+        return jsonResponse({
+            id: executionId,
+            tracked_policy_id: trackedPolicyId,
+            status: 'succeeded',
+            result_snapshot_created: true,
+            failure_message: null,
+            execute_started_at: '2026-03-25T09:00:00Z',
+            execute_finished_at: '2026-03-25T09:00:05Z',
+        });
+      }
+      
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => expect(screen.getByText('Slow Term Checks')).toBeTruthy());
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Check now' }));
+
+    // The polling takes at least 2 * 2000 = 4000ms.
+    await waitFor(() =>
+      expect(
+        screen.getByText('Slow Term Checks was checked and a policy update was detected.'),
+      ).toBeTruthy(),
+      { timeout: 6000 }
+    );
+    expect(screen.getByText('2 stored versions')).toBeTruthy();
+    expect(screen.getByText(/updated/i)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

- Introduce the durable tracked-policy check execution flow for SCRUM-104, including execution persistence, execution-status APIs, and frontend polling support.
- Harden the execution flow so missing resources return `404`, active-execution dedupe is race-safe, and the dashboard uses refreshed tracked-policy state after polling completes.
- Prevent infinite client polling by capping execution-status polling attempts and surfacing a user-visible timeout error when an execution never reaches a terminal state.
- Add focused backend/frontend regression coverage and document the final async-ready execution behavior.

## Linked story / work item

- Closes #25 
- Jira / story reference: [SCRUM-104](https://termsandconditionsanalyzer.atlassian.net/browse/SCRUM-104)

## Why / What / How

**Why**

- SCRUM-104 moves tracked-policy manual checks from an implicit synchronous action into an explicit execution model that can later hand off to queued/background processing.
- The initial implementation needed hardening around execution lookup, dedupe under contention, stale frontend success state, and stuck polling behavior.

**What changed**

- Added a first-class tracked-policy check execution model and persistence support for `pending`, `running`, `succeeded`, `failed`, and `timed_out` states.
- Exposed execution-aware API behavior for manual checks and execution-status lookup without changing the external wire contract introduced by SCRUM-104.
- Added service-layer lookup and exception translation so missing tracked policies and missing execution IDs return `404` instead of leaking internal exceptions.
- Hardened dedupe so concurrent creates recover cleanly to the active execution instead of surfacing a unique-constraint failure.
- Updated the dashboard hook to:
  - poll execution status until a terminal state is reached
  - prefer freshly reloaded tracked-policy state over stale envelope state
  - stop polling after a fixed attempt budget and show an actionable timeout error
- Updated the async-execution documentation to match the actual dedupe key, lifecycle rules, and failure-delivery semantics.

**How**

- Backend:
  - added a public execution lookup seam through the service layer instead of route-level access to repository internals
  - added repository-level active-execution conflict signaling and Postgres unique-violation translation
  - used service-level conflict recovery to reload and return the already-active execution
  - normalized tracked-policy-not-found handling at the `TrackedPolicyService` boundary
- Frontend:
  - kept the existing polling cadence and terminal-state handling
  - resolved success messaging from the refreshed tracked-policy list first, then fell back to the initial `/check` envelope
  - added a hard polling cap so the UI exits cleanly when an execution is stuck
- Tests:
  - added focused regression coverage for unknown execution IDs, unknown tracked policies, create-conflict recovery, stale envelope state, and stuck polling

## Acceptance criteria coverage

List each acceptance criterion from the story and explain how this PR satisfies it.

- [x] Criterion 1: Manual tracked-policy checks now return and persist explicit execution state that can be polled independently of the initial request.
- [x] Criterion 2: The API and UI correctly handle success, failure, timeout, and not-found cases without leaking internal errors or leaving the user stuck.
- [x] Criterion 3: Overlapping manual checks dedupe to a single active execution, and the dashboard refreshes to the newest tracked-policy state after completion.
- [x] Criterion 4: The implementation remains async-ready and the documented behavior matches the final code path.

## Changes made

- [x] Frontend
- [x] Backend
- [ ] Extension
- [ ] Infrastructure / DevOps
- [ ] AI / Analysis
- [ ] Security / Auth
- [ ] Notifications
- [x] Tests
- [x] Documentation

## Testing

What did you test, and how?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Not applicable

Details:

- Ran `python -m pytest backend/tests/test_check_execution_repository.py`
- Ran `python -m pytest backend/tests/test_check_execution_service.py`
- Ran `python -m pytest backend/tests/test_tracked_policy_service.py`
- Ran `python -m pytest backend/tests/test_tracked_policies_api.py`
- Ran `npm run test:frontend -- dashboard.test.tsx`
- Ran `python -m pytest backend/tests -k "tracked_policy or check_execution"`

## Reviewer checklist

- [x] PR matches the linked story
- [x] Acceptance criteria are addressed
- [x] Code is understandable and scoped appropriately
- [x] Tests or manual verification are included
- [x] No secrets or sensitive data are committed
- [x] Documentation updated if needed

## Notes

- This PR covers both the main SCRUM-104 execution-model work and the subsequent hardening that closed the review findings and Sentry Seer reports discovered during implementation.
